### PR TITLE
pimd: Modifying in_addr to ipaddr for IPv6 in required places.

### DIFF
--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1111,25 +1111,13 @@ const char *prefix_sg2str(const struct prefix_sg *sg, char *sg_str)
 		char src_str[INET_ADDRSTRLEN];
 		char grp_str[INET_ADDRSTRLEN];
 
+	if (sg->family == AF_INET) {
 		prefix_mcast_inet4_dump("<src?>", sg->src.ipaddr_v4, src_str,
 					sizeof(src_str));
 		prefix_mcast_inet4_dump("<grp?>", sg->grp.ipaddr_v4, grp_str,
 					sizeof(grp_str));
-
-		snprintf(sg_str, PREFIX_SG_STR_LEN, "(%s,%s)", src_str,
-			 grp_str);
-	} else if (sg->family == AF_INET6) {
-		char src_str[INET6_ADDRSTRLEN];
-		char grp_str[INET6_ADDRSTRLEN];
-
-		prefix_mcast_inet6_dump("<src?>", sg->src.ipaddr_v6, src_str,
-					sizeof(src_str));
-		prefix_mcast_inet6_dump("<grp?>", sg->grp.ipaddr_v6, grp_str,
-					sizeof(grp_str));
-
-		snprintf(sg_str, PREFIX_SG_STR_LEN, "(%s,%s)", src_str,
-			 grp_str);
 	}
+	snprintf(sg_str, PREFIX_SG_STR_LEN, "(%s,%s)", src_str, grp_str);
 
 	return sg_str;
 }

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1111,13 +1111,25 @@ const char *prefix_sg2str(const struct prefix_sg *sg, char *sg_str)
 		char src_str[INET_ADDRSTRLEN];
 		char grp_str[INET_ADDRSTRLEN];
 
-	if (sg->family == AF_INET) {
 		prefix_mcast_inet4_dump("<src?>", sg->src.ipaddr_v4, src_str,
 					sizeof(src_str));
 		prefix_mcast_inet4_dump("<grp?>", sg->grp.ipaddr_v4, grp_str,
 					sizeof(grp_str));
+
+		snprintf(sg_str, PREFIX_SG_STR_LEN, "(%s,%s)", src_str,
+			 grp_str);
+	} else if (sg->family == AF_INET6) {
+		char src_str[INET6_ADDRSTRLEN];
+		char grp_str[INET6_ADDRSTRLEN];
+
+		prefix_mcast_inet6_dump("<src?>", sg->src.ipaddr_v6, src_str,
+					sizeof(src_str));
+		prefix_mcast_inet6_dump("<grp?>", sg->grp.ipaddr_v6, grp_str,
+					sizeof(grp_str));
+
+		snprintf(sg_str, PREFIX_SG_STR_LEN, "(%s,%s)", src_str,
+			 grp_str);
 	}
-	snprintf(sg_str, PREFIX_SG_STR_LEN, "(%s,%s)", src_str, grp_str);
 
 	return sg_str;
 }

--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -471,7 +471,8 @@ static int pim_assert_do(struct pim_ifchannel *ch,
 	}
 	++pim_ifp->pim_ifstat_assert_send;
 
-	if (pim_msg_send(pim_ifp->pim_sock_fd, pim_ifp->primary_address,
+	if (pim_msg_send(pim_ifp->pim_sock_fd,
+			 pim_ifp->primary_address.ipaddr_v4,
 			 qpim_all_pim_routers_addr, pim_msg, pim_msg_size,
 			 ifp->name)) {
 		zlog_warn("%s: could not send PIM message on interface %s",
@@ -594,10 +595,11 @@ int assert_action_a1(struct pim_ifchannel *ch)
 	}
 
 	/* Switch to I_AM_WINNER before performing action_a3 below */
-	pim_ifassert_winner_set(
-		ch, PIM_IFASSERT_I_AM_WINNER, pim_ifp->primary_address,
-		pim_macro_spt_assert_metric(&ch->upstream->rpf,
-					    pim_ifp->primary_address));
+	pim_ifassert_winner_set(ch, PIM_IFASSERT_I_AM_WINNER,
+				pim_ifp->primary_address.ipaddr_v4,
+				pim_macro_spt_assert_metric(
+					&ch->upstream->rpf,
+					pim_ifp->primary_address.ipaddr_v4));
 
 	if (assert_action_a3(ch)) {
 		zlog_warn(

--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -309,8 +309,8 @@ int pim_assert_recv(struct interface *ifp, struct pim_neighbor *neigh,
 	assert(pim_ifp);
 	++pim_ifp->pim_ifstat_assert_recv;
 
-	return dispatch_assert(ifp, msg_source_addr.u.prefix4, sg.grp.ipaddr_v4,
-			       msg_metric);
+	return dispatch_assert(ifp, msg_source_addr.u.prefix4,
+			       sg.grp.ipaddr_v4, msg_metric);
 }
 
 /*

--- a/pimd/pim_bfd.c
+++ b/pimd/pim_bfd.c
@@ -95,7 +95,8 @@ void pim_bfd_info_nbr_create(struct pim_interface *pim_ifp,
 	bfd_sess_set_timers(
 		neigh->bfd_session, pim_ifp->bfd_config.detection_multiplier,
 		pim_ifp->bfd_config.min_rx, pim_ifp->bfd_config.min_tx);
-	bfd_sess_set_ipv4_addrs(neigh->bfd_session, NULL, &neigh->source_addr);
+	bfd_sess_set_ipv4_addrs(neigh->bfd_session, NULL,
+				&neigh->source_addr.ipaddr_v4);
 	bfd_sess_set_interface(neigh->bfd_session, neigh->interface->name);
 	bfd_sess_set_vrf(neigh->bfd_session, neigh->interface->vrf->vrf_id);
 	bfd_sess_set_profile(neigh->bfd_session, pim_ifp->bfd_config.profile);

--- a/pimd/pim_br.c
+++ b/pimd/pim_br.c
@@ -43,7 +43,8 @@ struct in_addr pim_br_get_pmbr(struct prefix_sg *sg)
 	struct pim_br *pim_br;
 
 	for (ALL_LIST_ELEMENTS_RO(pim_br_list, node, pim_br)) {
-		if (sg->src.ipaddr_v4.s_addr == pim_br->sg.src.ipaddr_v4.s_addr
+		if (sg->src.ipaddr_v4.s_addr
+			    == pim_br->sg.src.ipaddr_v4.s_addr
 		    && sg->grp.ipaddr_v4.s_addr
 			       == pim_br->sg.grp.ipaddr_v4.s_addr)
 			return pim_br->pmbr;
@@ -58,7 +59,8 @@ void pim_br_set_pmbr(struct prefix_sg *sg, struct in_addr br)
 	struct pim_br *pim_br;
 
 	for (ALL_LIST_ELEMENTS(pim_br_list, node, next, pim_br)) {
-		if (sg->src.ipaddr_v4.s_addr == pim_br->sg.src.ipaddr_v4.s_addr
+		if (sg->src.ipaddr_v4.s_addr
+			    == pim_br->sg.src.ipaddr_v4.s_addr
 		    && sg->grp.ipaddr_v4.s_addr
 			       == pim_br->sg.grp.ipaddr_v4.s_addr)
 			break;
@@ -83,7 +85,8 @@ void pim_br_clear_pmbr(struct prefix_sg *sg)
 	struct pim_br *pim_br;
 
 	for (ALL_LIST_ELEMENTS(pim_br_list, node, next, pim_br)) {
-		if (sg->src.ipaddr_v4.s_addr == pim_br->sg.src.ipaddr_v4.s_addr
+		if (sg->src.ipaddr_v4.s_addr
+			    == pim_br->sg.src.ipaddr_v4.s_addr
 		    && sg->grp.ipaddr_v4.s_addr
 			       == pim_br->sg.grp.ipaddr_v4.s_addr)
 			break;

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -713,8 +713,9 @@ static bool pim_bsm_send_intf(uint8_t *buf, int len, struct interface *ifp,
 		return false;
 	}
 
-	if (pim_msg_send(pim_ifp->pim_sock_fd, pim_ifp->primary_address,
-			 dst_addr, buf, len, ifp->name)) {
+	if (pim_msg_send(pim_ifp->pim_sock_fd,
+			 pim_ifp->primary_address.ipaddr_v4, dst_addr, buf, len,
+			 ifp->name)) {
 		zlog_warn("%s: Could not send BSM message on interface: %s",
 			  __func__, ifp->name);
 		return false;
@@ -964,7 +965,8 @@ bool pim_bsm_new_nbr_fwd(struct pim_neighbor *neigh, struct interface *ifp)
 	pim_ifp = ifp->info;
 
 	/* DR only forwards BSM packet */
-	if (pim_ifp->pim_dr_addr.s_addr == pim_ifp->primary_address.s_addr) {
+	if (pim_ifp->pim_dr_addr.ipaddr_v4.s_addr
+	    == pim_ifp->primary_address.ipaddr_v4.s_addr) {
 		if (PIM_DEBUG_BSM)
 			zlog_debug(
 				"%s: It is not DR, so don't forward BSM packet",

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -956,8 +956,8 @@ bool pim_bsm_new_nbr_fwd(struct pim_neighbor *neigh, struct interface *ifp)
 	bool ret = false;
 
 	if (PIM_DEBUG_BSM) {
-		pim_inet4_dump("<src?>", neigh->source_addr, neigh_src_str,
-			       sizeof(neigh_src_str));
+		pim_inet4_dump("<src?>", neigh->source_addr.ipaddr_v4,
+			       neigh_src_str, sizeof(neigh_src_str));
 		zlog_debug("%s: New neighbor %s seen on %s", __func__,
 			   neigh_src_str, ifp->name);
 	}
@@ -995,7 +995,7 @@ bool pim_bsm_new_nbr_fwd(struct pim_neighbor *neigh, struct interface *ifp)
 			zlog_debug("%s: Sending BSM mcast to %s", __func__,
 				   neigh_src_str);
 	} else {
-		dst_addr = neigh->source_addr;
+		dst_addr = neigh->source_addr.ipaddr_v4;
 		if (PIM_DEBUG_BSM)
 			zlog_debug("%s: Sending BSM ucast to %s", __func__,
 				   neigh_src_str);

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -679,8 +679,7 @@ void pim_bsm_clear(struct pim_instance *pim)
 		if (pim_rpf_addr_is_inaddr_none(&trp_info->rp)) {
 			pim_upstream_rpf_clear(pim, up);
 			pim_rp_set_upstream_addr(pim, &up->upstream_addr,
-						 up->sg.src.ipaddr_v4,
-						 up->sg.grp.ipaddr_v4);
+						 up->sg.src.ipaddr_v4, up->sg.grp.ipaddr_v4);
 		} else {
 			/* RP found for the group grp */
 			pim_upstream_update(pim, up);

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -678,7 +678,8 @@ void pim_bsm_clear(struct pim_instance *pim)
 		/* RP not found for the group grp */
 		if (pim_rpf_addr_is_inaddr_none(&trp_info->rp)) {
 			pim_upstream_rpf_clear(pim, up);
-			pim_rp_set_upstream_addr(pim, &up->upstream_addr,
+			pim_rp_set_upstream_addr(pim,
+						 &up->upstream_addr.ipaddr_v4,
 						 up->sg.src.ipaddr_v4, up->sg.grp.ipaddr_v4);
 		} else {
 			/* RP found for the group grp */

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -546,7 +546,7 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 				}
 				json_object_string_addf(json_row, "querierIp",
 							"%pI4",
-							&igmp->querier_addr);
+							&igmp->querier_addr.ipaddr_v4);
 
 				json_object_object_add(json, ifp->name,
 						       json_row);
@@ -563,12 +563,12 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 						? (igmp->mtrace_only ? "mtrc"
 								     : "up")
 						: "down",
-					inet_ntop(AF_INET, &igmp->ifaddr, buf,
+					inet_ntop(AF_INET, &igmp->ifaddr.ipaddr_v4, buf,
 						  sizeof(buf)),
 					pim_ifp->version,
 					igmp->t_igmp_query_timer ? "local"
 								 : "other",
-					&igmp->querier_addr, query_hhmmss,
+					&igmp->querier_addr.ipaddr_v4, query_hhmmss,
 					uptime);
 			}
 		}
@@ -674,7 +674,7 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 						       : "other");
 				json_object_string_addf(json_row, "querierIp",
 							"%pI4",
-							&igmp->querier_addr);
+							&igmp->querier_addr.ipaddr_v4);
 				json_object_int_add(json_row, "queryStartCount",
 						    igmp->startup_query_count);
 				json_object_string_add(json_row,
@@ -745,9 +745,9 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 					igmp->t_igmp_query_timer ? "local"
 								 : "other");
 				vty_out(vty, "QuerierIp   : %pI4",
-					&igmp->querier_addr);
+					&igmp->querier_addr.ipaddr_v4);
 				if (pim_ifp->primary_address.ipaddr_v4.s_addr
-				    == igmp->querier_addr.s_addr)
+				    == igmp->querier_addr.ipaddr_v4.s_addr)
 					vty_out(vty, " (this router)\n");
 				else
 					vty_out(vty, "\n");

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1773,12 +1773,10 @@ static void pim_show_join(struct pim_instance *pim, struct vty *vty,
 
 		RB_FOREACH (ch, pim_ifchannel_rb, &pim_ifp->ifchannel_rb) {
 			if (sg->grp.ipaddr_v4.s_addr != INADDR_ANY
-			    && sg->grp.ipaddr_v4.s_addr
-				       != ch->sg.grp.ipaddr_v4.s_addr)
+			    && sg->grp.ipaddr_v4.s_addr != ch->sg.grp.ipaddr_v4.s_addr)
 				continue;
 			if (sg->src.ipaddr_v4.s_addr != INADDR_ANY
-			    && sg->src.ipaddr_v4.s_addr
-				       != ch->sg.src.ipaddr_v4.s_addr)
+			    && sg->src.ipaddr_v4.s_addr != ch->sg.src.ipaddr_v4.s_addr)
 				continue;
 			pim_show_join_helper(vty, pim_ifp, ch, json, now, uj);
 		} /* scan interface channels */
@@ -2483,10 +2481,8 @@ static void pim_show_upstream(struct pim_instance *pim, struct vty *vty,
 		    && sg->src.ipaddr_v4.s_addr != up->sg.src.ipaddr_v4.s_addr)
 			continue;
 
-		pim_inet4_dump("<src?>", up->sg.src.ipaddr_v4, src_str,
-			       sizeof(src_str));
-		pim_inet4_dump("<grp?>", up->sg.grp.ipaddr_v4, grp_str,
-			       sizeof(grp_str));
+		pim_inet4_dump("<src?>", up->sg.src.ipaddr_v4, src_str, sizeof(src_str));
+		pim_inet4_dump("<grp?>", up->sg.grp.ipaddr_v4, grp_str, sizeof(grp_str));
 		pim_time_uptime(uptime, sizeof(uptime),
 				now - up->state_transition);
 		pim_time_timer_to_hhmmss(join_timer, sizeof(join_timer),
@@ -2713,10 +2709,8 @@ static void pim_show_join_desired_helper(struct pim_instance *pim,
 	char grp_str[INET_ADDRSTRLEN];
 	json_object *json_row = NULL;
 
-	pim_inet4_dump("<src?>", up->sg.src.ipaddr_v4, src_str,
-		       sizeof(src_str));
-	pim_inet4_dump("<grp?>", up->sg.grp.ipaddr_v4, grp_str,
-		       sizeof(grp_str));
+	pim_inet4_dump("<src?>", up->sg.src.ipaddr_v4, src_str, sizeof(src_str));
+	pim_inet4_dump("<grp?>", up->sg.grp.ipaddr_v4, grp_str, sizeof(grp_str));
 
 	if (uj) {
 		json_object_object_get_ex(json, grp_str, &json_group);
@@ -4696,10 +4690,8 @@ static void pim_show_jp_agg_helper(struct vty *vty,
 	char grp_str[INET_ADDRSTRLEN];
 	char rpf_str[INET_ADDRSTRLEN];
 
-	pim_inet4_dump("<src?>", up->sg.src.ipaddr_v4, src_str,
-		       sizeof(src_str));
-	pim_inet4_dump("<grp?>", up->sg.grp.ipaddr_v4, grp_str,
-		       sizeof(grp_str));
+	pim_inet4_dump("<src?>", up->sg.src.ipaddr_v4, src_str, sizeof(src_str));
+	pim_inet4_dump("<grp?>", up->sg.grp.ipaddr_v4, grp_str, sizeof(grp_str));
 	/* pius->address.s_addr */
 	pim_inet4_dump("<rpf?>", neigh->source_addr, rpf_str, sizeof(rpf_str));
 
@@ -4881,10 +4873,8 @@ static void pim_show_mlag_up_detail(struct vrf *vrf,
 		    && !pim_up_mlag_is_local(up))
 			continue;
 
-		pim_inet4_dump("<src?>", up->sg.src.ipaddr_v4, src_str,
-			       sizeof(src_str));
-		pim_inet4_dump("<grp?>", up->sg.grp.ipaddr_v4, grp_str,
-			       sizeof(grp_str));
+		pim_inet4_dump("<src?>", up->sg.src.ipaddr_v4, src_str, sizeof(src_str));
+		pim_inet4_dump("<grp?>", up->sg.grp.ipaddr_v4, grp_str, sizeof(grp_str));
 		/* XXX: strcmps are clearly inefficient. we should do uint comps
 		 * here instead.
 		 */
@@ -4930,10 +4920,8 @@ static void pim_show_mlag_up_vrf(struct vrf *vrf, struct vty *vty, bool uj)
 		    && !(up->flags & PIM_UPSTREAM_FLAG_MASK_MLAG_INTERFACE)
 		    && !pim_up_mlag_is_local(up))
 			continue;
-		pim_inet4_dump("<src?>", up->sg.src.ipaddr_v4, src_str,
-			       sizeof(src_str));
-		pim_inet4_dump("<grp?>", up->sg.grp.ipaddr_v4, grp_str,
-			       sizeof(grp_str));
+		pim_inet4_dump("<src?>", up->sg.src.ipaddr_v4, src_str, sizeof(src_str));
+		pim_inet4_dump("<grp?>", up->sg.grp.ipaddr_v4, grp_str, sizeof(grp_str));
 		if (uj) {
 			json_object *own_list = NULL;
 
@@ -5957,12 +5945,10 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty,
 			continue;
 
 		if (sg->grp.ipaddr_v4.s_addr != INADDR_ANY
-		    && sg->grp.ipaddr_v4.s_addr
-			       != c_oil->oil.mfcc_mcastgrp.s_addr)
+		    && sg->grp.ipaddr_v4.s_addr != c_oil->oil.mfcc_mcastgrp.s_addr)
 			continue;
 		if (sg->src.ipaddr_v4.s_addr != INADDR_ANY
-		    && sg->src.ipaddr_v4.s_addr
-			       != c_oil->oil.mfcc_origin.s_addr)
+		    && sg->src.ipaddr_v4.s_addr != c_oil->oil.mfcc_origin.s_addr)
 			continue;
 
 		pim_inet4_dump("<group?>", c_oil->oil.mfcc_mcastgrp, grp_str,
@@ -10526,15 +10512,12 @@ static void pim_show_vxlan_sg_entry(struct pim_vxlan_sg *vxlan_sg,
 	else
 		oif_name = vxlan_sg->term_oif?vxlan_sg->term_oif->name:"";
 
-	if (cwd->addr_match
-	    && (vxlan_sg->sg.src.ipaddr_v4.s_addr != cwd->addr.s_addr)
-	    && (vxlan_sg->sg.grp.ipaddr_v4.s_addr != cwd->addr.s_addr)) {
+	if (cwd->addr_match && (vxlan_sg->sg.src.ipaddr_v4.s_addr != cwd->addr.s_addr) &&
+	    (vxlan_sg->sg.grp.ipaddr_v4.s_addr != cwd->addr.s_addr)) {
 		return;
 	}
-	pim_inet4_dump("<src?>", vxlan_sg->sg.src.ipaddr_v4, src_str,
-		       sizeof(src_str));
-	pim_inet4_dump("<grp?>", vxlan_sg->sg.grp.ipaddr_v4, grp_str,
-		       sizeof(grp_str));
+	pim_inet4_dump("<src?>", vxlan_sg->sg.src.ipaddr_v4, src_str, sizeof(src_str));
+	pim_inet4_dump("<grp?>", vxlan_sg->sg.grp.ipaddr_v4, grp_str, sizeof(grp_str));
 	if (json) {
 		json_object_object_get_ex(json, grp_str, &cwd->json_group);
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -108,7 +108,7 @@ static void pim_show_assert_helper(struct vty *vty,
 	char timer[10];
 	char buf[PREFIX_STRLEN];
 
-	ifaddr = pim_ifp->primary_address;
+	ifaddr = pim_ifp->primary_address.ipaddr_v4;
 
 	pim_inet4_dump("<ch_src?>", ch->sg.src.ipaddr_v4, ch_src_str,
 		       sizeof(ch_src_str));
@@ -159,7 +159,7 @@ static void pim_show_assert_internal_helper(struct vty *vty,
 	struct in_addr ifaddr;
 	char buf[PREFIX_STRLEN];
 
-	ifaddr = pim_ifp->primary_address;
+	ifaddr = pim_ifp->primary_address.ipaddr_v4;
 
 	pim_inet4_dump("<ch_src?>", ch->sg.src.ipaddr_v4, ch_src_str,
 		       sizeof(ch_src_str));
@@ -212,10 +212,10 @@ static void pim_show_assert_metric_helper(struct vty *vty,
 	struct in_addr ifaddr;
 	char buf[PREFIX_STRLEN];
 
-	ifaddr = pim_ifp->primary_address;
+	ifaddr = pim_ifp->primary_address.ipaddr_v4;
 
 	am = pim_macro_spt_assert_metric(&ch->upstream->rpf,
-					 pim_ifp->primary_address);
+					 pim_ifp->primary_address.ipaddr_v4);
 
 	pim_inet4_dump("<ch_src?>", ch->sg.src.ipaddr_v4, ch_src_str,
 		       sizeof(ch_src_str));
@@ -263,7 +263,7 @@ static void pim_show_assert_winner_metric_helper(struct vty *vty,
 	char metr_str[16];
 	char buf[PREFIX_STRLEN];
 
-	ifaddr = pim_ifp->primary_address;
+	ifaddr = pim_ifp->primary_address.ipaddr_v4;
 
 	am = &ch->ifassert_winner_metric;
 
@@ -321,7 +321,7 @@ static void json_object_pim_ifp_add(struct json_object *json,
 	json_object_string_add(json, "name", ifp->name);
 	json_object_string_add(json, "state", if_is_up(ifp) ? "up" : "down");
 	json_object_string_addf(json, "address", "%pI4",
-				&pim_ifp->primary_address);
+				&pim_ifp->primary_address.ipaddr_v4);
 	json_object_int_add(json, "index", ifp->ifindex);
 
 	if (if_is_multicast(ifp))
@@ -727,12 +727,12 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 			} else {
 				vty_out(vty, "Interface : %s\n", ifp->name);
 				vty_out(vty, "State     : %s\n",
-					if_is_up(ifp) ? (igmp->mtrace_only ?
-							 "mtrace"
-							 : "up")
-					: "down");
+					if_is_up(ifp)
+						? (igmp->mtrace_only ? "mtrace"
+								     : "up")
+						: "down");
 				vty_out(vty, "Address   : %pI4\n",
-					&pim_ifp->primary_address);
+					&pim_ifp->primary_address.ipaddr_v4);
 				vty_out(vty, "Uptime    : %s\n", uptime);
 				vty_out(vty, "Version   : %d\n",
 					pim_ifp->version);
@@ -743,10 +743,10 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 				vty_out(vty, "-------\n");
 				vty_out(vty, "Querier     : %s\n",
 					igmp->t_igmp_query_timer ? "local"
-					: "other");
+								 : "other");
 				vty_out(vty, "QuerierIp   : %pI4",
 					&igmp->querier_addr);
-				if (pim_ifp->primary_address.s_addr
+				if (pim_ifp->primary_address.ipaddr_v4.s_addr
 				    == igmp->querier_addr.s_addr)
 					vty_out(vty, " (this router)\n");
 				else
@@ -957,8 +957,8 @@ static void pim_show_interfaces_single(struct pim_instance *pim,
 			continue;
 
 		found_ifname = 1;
-		ifaddr = pim_ifp->primary_address;
-		pim_inet4_dump("<dr?>", pim_ifp->pim_dr_addr, dr_str,
+		ifaddr = pim_ifp->primary_address.ipaddr_v4;
+		pim_inet4_dump("<dr?>", pim_ifp->pim_dr_addr.ipaddr_v4, dr_str,
 			       sizeof(dr_str));
 		pim_time_uptime_begin(dr_uptime, sizeof(dr_uptime), now,
 				      pim_ifp->pim_dr_election_last);
@@ -978,10 +978,11 @@ static void pim_show_interfaces_single(struct pim_instance *pim,
 			json_row = json_object_new_object();
 			json_object_pim_ifp_add(json_row, ifp);
 
-			if (pim_ifp->update_source.s_addr != INADDR_ANY) {
+			if (pim_ifp->update_source.ipaddr_v4.s_addr
+			    != INADDR_ANY) {
 				json_object_string_addf(
 					json_row, "useSource", "%pI4",
-					&pim_ifp->update_source);
+					&pim_ifp->update_source.ipaddr_v4);
 			}
 			if (pim_ifp->sec_addr_list) {
 				json_object *sec_list = NULL;
@@ -1156,9 +1157,10 @@ static void pim_show_interfaces_single(struct pim_instance *pim,
 			vty_out(vty, "Interface  : %s\n", ifp->name);
 			vty_out(vty, "State      : %s\n",
 				if_is_up(ifp) ? "up" : "down");
-			if (pim_ifp->update_source.s_addr != INADDR_ANY) {
+			if (pim_ifp->update_source.ipaddr_v4.s_addr
+			    != INADDR_ANY) {
 				vty_out(vty, "Use Source : %pI4\n",
-					&pim_ifp->update_source);
+					&pim_ifp->update_source.ipaddr_v4);
 			}
 			if (pim_ifp->sec_addr_list) {
 				vty_out(vty, "Address    : %pI4 (primary)\n",
@@ -1435,10 +1437,10 @@ static void pim_show_interfaces(struct pim_instance *pim, struct vty *vty,
 		json_object_int_add(json_row, "pimIfChannels", pim_ifchannels);
 		json_object_int_add(json_row, "firstHopRouterCount", fhr);
 		json_object_string_addf(json_row, "pimDesignatedRouter", "%pI4",
-					&pim_ifp->pim_dr_addr);
+					&pim_ifp->pim_dr_addr.ipaddr_v4);
 
-		if (pim_ifp->pim_dr_addr.s_addr
-		    == pim_ifp->primary_address.s_addr)
+		if (pim_ifp->pim_dr_addr.ipaddr_v4.s_addr
+		    == pim_ifp->primary_address.ipaddr_v4.s_addr)
 			json_object_boolean_true_add(
 				json_row, "pimDesignatedRouterLocal");
 
@@ -1692,7 +1694,7 @@ static void pim_show_join_helper(struct vty *vty, struct pim_interface *pim_ifp,
 	char prune[10];
 	char buf[PREFIX_STRLEN];
 
-	ifaddr = pim_ifp->primary_address;
+	ifaddr = pim_ifp->primary_address.ipaddr_v4;
 
 	pim_inet4_dump("<ch_src?>", ch->sg.src.ipaddr_v4, ch_src_str,
 		       sizeof(ch_src_str));
@@ -2326,7 +2328,7 @@ static void pim_show_neighbors_secondary(struct pim_instance *pim,
 		if (pim_ifp->pim_sock_fd < 0)
 			continue;
 
-		ifaddr = pim_ifp->primary_address;
+		ifaddr = pim_ifp->primary_address.ipaddr_v4;
 
 		for (ALL_LIST_ELEMENTS_RO(pim_ifp->pim_neighbor_list, neighnode,
 					  neigh)) {
@@ -5710,14 +5712,15 @@ static void show_multicast_interfaces(struct pim_instance *pim, struct vty *vty,
 				safe_strerror(errno));
 		}
 
-		ifaddr = pim_ifp->primary_address;
+		ifaddr = pim_ifp->primary_address.ipaddr_v4;
 		if (uj) {
 			json_row = json_object_new_object();
 			json_object_string_add(json_row, "name", ifp->name);
 			json_object_string_add(json_row, "state",
 					       if_is_up(ifp) ? "up" : "down");
-			json_object_string_addf(json_row, "address", "%pI4",
-						&pim_ifp->primary_address);
+			json_object_string_addf(
+				json_row, "address", "%pI4",
+				&pim_ifp->primary_address.ipaddr_v4);
 			json_object_int_add(json_row, "ifIndex", ifp->ifindex);
 			json_object_int_add(json_row, "vif",
 					    pim_ifp->mroute_vif_index);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1013,10 +1013,11 @@ static void pim_show_interfaces_single(struct pim_instance *pim,
 					     neighnode, neigh)) {
 					json_pim_neighbor =
 						json_object_new_object();
-					pim_inet4_dump("<src?>",
-						       neigh->source_addr,
-						       neigh_src_str,
-						       sizeof(neigh_src_str));
+					pim_inet4_dump(
+						"<src?>",
+						neigh->source_addr.ipaddr_v4,
+						neigh_src_str,
+						sizeof(neigh_src_str));
 					pim_time_uptime(uptime, sizeof(uptime),
 							now - neigh->creation);
 					pim_time_timer_to_hhmmss(
@@ -1188,9 +1189,9 @@ static void pim_show_interfaces_single(struct pim_instance *pim,
 					print_header = 0;
 				}
 
-				pim_inet4_dump("<src?>", neigh->source_addr,
-					       neigh_src_str,
-					       sizeof(neigh_src_str));
+				pim_inet4_dump(
+					"<src?>", neigh->source_addr.ipaddr_v4,
+					neigh_src_str, sizeof(neigh_src_str));
 				pim_time_uptime(uptime, sizeof(uptime),
 						now - neigh->creation);
 				pim_time_timer_to_hhmmss(expire, sizeof(expire),
@@ -1830,7 +1831,7 @@ static void pim_show_neighbors_single(struct pim_instance *pim, struct vty *vty,
 
 		for (ALL_LIST_ELEMENTS_RO(pim_ifp->pim_neighbor_list, neighnode,
 					  neigh)) {
-			pim_inet4_dump("<src?>", neigh->source_addr,
+			pim_inet4_dump("<src?>", neigh->source_addr.ipaddr_v4,
 				       neigh_src_str, sizeof(neigh_src_str));
 
 			/*
@@ -2261,7 +2262,7 @@ static void pim_show_neighbors(struct pim_instance *pim, struct vty *vty,
 
 		for (ALL_LIST_ELEMENTS_RO(pim_ifp->pim_neighbor_list, neighnode,
 					  neigh)) {
-			pim_inet4_dump("<src?>", neigh->source_addr,
+			pim_inet4_dump("<src?>", neigh->source_addr.ipaddr_v4,
 				       neigh_src_str, sizeof(neigh_src_str));
 			pim_time_uptime(uptime, sizeof(uptime),
 					now - neigh->creation);
@@ -2339,7 +2340,7 @@ static void pim_show_neighbors_secondary(struct pim_instance *pim,
 			if (!neigh->prefix_list)
 				continue;
 
-			pim_inet4_dump("<src?>", neigh->source_addr,
+			pim_inet4_dump("<src?>", neigh->source_addr.ipaddr_v4,
 				       neigh_src_str, sizeof(neigh_src_str));
 
 			for (ALL_LIST_ELEMENTS_RO(neigh->prefix_list,
@@ -4695,11 +4696,11 @@ static void pim_show_jp_agg_helper(struct vty *vty,
 	pim_inet4_dump("<src?>", up->sg.src.ipaddr_v4, src_str, sizeof(src_str));
 	pim_inet4_dump("<grp?>", up->sg.grp.ipaddr_v4, grp_str, sizeof(grp_str));
 	/* pius->address.s_addr */
-	pim_inet4_dump("<rpf?>", neigh->source_addr, rpf_str, sizeof(rpf_str));
+	pim_inet4_dump("<rpf?>", neigh->source_addr.ipaddr_v4, rpf_str,
+		       sizeof(rpf_str));
 
-	vty_out(vty, "%-16s %-15s %-15s %-15s %5s\n",
-		ifp->name, rpf_str, src_str,
-		grp_str, is_join?"J":"P");
+	vty_out(vty, "%-16s %-15s %-15s %-15s %5s\n", ifp->name, rpf_str,
+		src_str, grp_str, is_join ? "J" : "P");
 }
 
 static void pim_show_jp_agg_list(struct pim_instance *pim, struct vty *vty)

--- a/pimd/pim_hello.c
+++ b/pimd/pim_hello.c
@@ -379,8 +379,8 @@ int pim_hello_recv(struct interface *ifp, struct in_addr src_addr,
 					ifp->name);
 			}
 
-			pim_upstream_rpf_genid_changed(pim_ifp->pim,
-						       neigh->source_addr);
+			pim_upstream_rpf_genid_changed(
+				pim_ifp->pim, neigh->source_addr.ipaddr_v4);
 
 			pim_neighbor_delete(ifp, neigh, "GenID mismatch");
 			neigh = pim_neighbor_add(ifp, src_addr, hello_options,

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1124,7 +1124,7 @@ struct pim_neighbor *pim_if_find_neighbor(struct interface *ifp,
 				  neigh)) {
 
 		/* primary address ? */
-		if (neigh->source_addr.s_addr == addr.s_addr)
+		if (neigh->source_addr.ipaddr_v4.s_addr == addr.s_addr)
 			return neigh;
 
 		/* secondary address ? */

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -58,7 +58,9 @@
 #define PIM_IF_DONT_PIM_CAN_DISABLE_JOIN_SUPPRESSION(options)                  \
 	((options) &= ~PIM_IF_MASK_PIM_CAN_DISABLE_JOIN_SUPPRESSION)
 
-#define PIM_I_am_DR(pim_ifp) (pim_ifp)->pim_dr_addr.s_addr == (pim_ifp)->primary_address.s_addr
+#define PIM_I_am_DR(pim_ifp)                                                   \
+	(pim_ifp)->pim_dr_addr.ipaddr_v4.s_addr                                \
+		== (pim_ifp)->primary_address.ipaddr_v4.s_addr
 #define PIM_I_am_DualActive(pim_ifp) (pim_ifp)->activeactive == true
 
 /* Macros for interface flags */
@@ -95,10 +97,10 @@ struct pim_interface {
 	ifindex_t mroute_vif_index;
 	struct pim_instance *pim;
 
-	struct in_addr primary_address; /* remember addr to detect change */
-	struct list *sec_addr_list;     /* list of struct pim_secondary_addr */
-	struct in_addr update_source;   /* user can statically set the primary
-					 * address of the interface */
+	struct ipaddr primary_address; /* remember addr to detect change */
+	struct list *sec_addr_list;    /* list of struct pim_secondary_addr */
+	struct ipaddr update_source;   /* user can statically set the primary
+					* address of the interface */
 
 	int version;			  /* IGMP or MLD version */
 	int default_robustness_variable;  /* IGMP or MLD QRV */
@@ -144,7 +146,7 @@ struct pim_interface {
 	int64_t pim_dr_election_last; /* timestamp */
 	int pim_dr_election_count;
 	int pim_dr_election_changes;
-	struct in_addr pim_dr_addr;
+	struct ipaddr pim_dr_addr;
 	uint32_t pim_dr_priority;	  /* config */
 	int pim_dr_num_nondrpri_neighbors; /* neighbors without dr_pri */
 

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -713,7 +713,7 @@ static int on_ifjoin_prune_pending_timer(struct thread *t)
 
 				rpf.source_nexthop.interface = ifp;
 				rpf.rpf_addr.u.prefix4 =
-					pim_ifp->primary_address;
+					pim_ifp->primary_address.ipaddr_v4;
 				pim_jp_agg_single_upstream_send(
 					&rpf, ch->upstream, 0);
 			}
@@ -831,7 +831,8 @@ static int nonlocal_upstream(int is_join, struct interface *recv_ifp,
 	recv_pim_ifp = recv_ifp->info;
 	assert(recv_pim_ifp);
 
-	is_local = (upstream.s_addr == recv_pim_ifp->primary_address.s_addr);
+	is_local = (upstream.s_addr
+		    == recv_pim_ifp->primary_address.ipaddr_v4.s_addr);
 
 	if (is_local)
 		return 0;

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -167,9 +167,9 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
 		 * being inherited.  So let's figure out what
 		 * needs to be done here
 		 */
-		if ((ch->sg.src.ipaddr_v4.s_addr != INADDR_ANY)
-		    && pim_upstream_evaluate_join_desired_interface(
-			       ch->upstream, ch, ch->parent))
+		if ((ch->sg.src.ipaddr_v4.s_addr != INADDR_ANY) &&
+				pim_upstream_evaluate_join_desired_interface(
+					ch->upstream, ch, ch->parent))
 			pim_channel_add_oif(ch->upstream->channel_oil,
 					ch->interface,
 					PIM_OIF_FLAG_PROTO_STAR,
@@ -1362,10 +1362,8 @@ void pim_ifchannel_update_could_assert(struct pim_ifchannel *ch)
 	if (PIM_DEBUG_PIM_EVENTS) {
 		char src_str[INET_ADDRSTRLEN];
 		char grp_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<src?>", ch->sg.src.ipaddr_v4, src_str,
-			       sizeof(src_str));
-		pim_inet4_dump("<grp?>", ch->sg.grp.ipaddr_v4, grp_str,
-			       sizeof(grp_str));
+		pim_inet4_dump("<src?>", ch->sg.src.ipaddr_v4, src_str, sizeof(src_str));
+		pim_inet4_dump("<grp?>", ch->sg.grp.ipaddr_v4, grp_str, sizeof(grp_str));
 		zlog_debug("%s: CouldAssert(%s,%s,%s) changed from %d to %d",
 			   __func__, src_str, grp_str, ch->interface->name,
 			   old_couldassert, new_couldassert);
@@ -1447,10 +1445,8 @@ void pim_ifchannel_update_assert_tracking_desired(struct pim_ifchannel *ch)
 	if (PIM_DEBUG_PIM_EVENTS) {
 		char src_str[INET_ADDRSTRLEN];
 		char grp_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<src?>", ch->sg.src.ipaddr_v4, src_str,
-			       sizeof(src_str));
-		pim_inet4_dump("<grp?>", ch->sg.grp.ipaddr_v4, grp_str,
-			       sizeof(grp_str));
+		pim_inet4_dump("<src?>", ch->sg.src.ipaddr_v4, src_str, sizeof(src_str));
+		pim_inet4_dump("<grp?>", ch->sg.grp.ipaddr_v4, grp_str, sizeof(grp_str));
 		zlog_debug(
 			"%s: AssertTrackingDesired(%s,%s,%s) changed from %d to %d",
 			__func__, src_str, grp_str, ch->interface->name,

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -386,7 +386,8 @@ static int igmp_recv_query(struct igmp_sock *igmp, int query_version,
 				ntohl(igmp->ifaddr.s_addr), from_str,
 				ntohl(from.s_addr));
 		}
-		if (ntohl(from.s_addr) < ntohl(igmp->querier_addr.s_addr))
+		if (ntohl(from.s_addr)
+		    < ntohl(igmp->querier_addr.s_addr))
 			igmp->querier_addr.s_addr = from.s_addr;
 
 		pim_igmp_other_querier_timer_on(igmp);
@@ -651,8 +652,8 @@ void pim_igmp_general_query_on(struct igmp_sock *igmp)
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char ifaddr_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
-			       sizeof(ifaddr_str));
+		pim_inet4_dump("<ifaddr?>", igmp->ifaddr,
+			       ifaddr_str, sizeof(ifaddr_str));
 		zlog_debug(
 			"Querier %s scheduling %d-second (%s) TIMER event for IGMP query on fd=%d",
 			ifaddr_str, query_interval,

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -118,7 +118,7 @@ static void igmp_sock_dump(array_t *igmp_sock_array)
 		struct igmp_sock *igmp = array_get(igmp_sock_array, i);
 
 		zlog_debug("%s %s: [%d/%d] igmp_addr=%pI4 fd=%d", __FILE__,
-			   __func__, i, size, &igmp->ifaddr,
+			   __func__, i, size, &igmp->ifaddr.ipaddr_v4,
 			   igmp->fd);
 	}
 }
@@ -135,7 +135,7 @@ struct igmp_sock *pim_igmp_sock_lookup_ifaddr(struct list *igmp_sock_list,
 #endif
 
 	for (ALL_LIST_ELEMENTS_RO(igmp_sock_list, sock_node, igmp))
-		if (ifaddr.s_addr == igmp->ifaddr.s_addr)
+		if (ifaddr.s_addr == igmp->ifaddr.ipaddr_v4.s_addr)
 			return igmp;
 
 	return NULL;
@@ -151,12 +151,12 @@ static int pim_igmp_other_querier_expire(struct thread *t)
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char ifaddr_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
+		pim_inet4_dump("<ifaddr?>", igmp->ifaddr.ipaddr_v4, ifaddr_str,
 			       sizeof(ifaddr_str));
 		zlog_debug("%s: Querier %s resuming", __func__, ifaddr_str);
 	}
 	/* Mark the interface address as querier address */
-	igmp->querier_addr = igmp->ifaddr;
+	igmp->querier_addr.ipaddr_v4 = igmp->ifaddr.ipaddr_v4;
 
 	/*
 	  We are the current querier, then
@@ -189,8 +189,8 @@ void pim_igmp_other_querier_timer_on(struct igmp_sock *igmp)
 
 		if (PIM_DEBUG_IGMP_TRACE) {
 			char ifaddr_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
-				       sizeof(ifaddr_str));
+			pim_inet4_dump("<ifaddr?>", igmp->ifaddr.ipaddr_v4,
+				       ifaddr_str, sizeof(ifaddr_str));
 			zlog_debug(
 				"Querier %s resetting TIMER event for Other-Querier-Present",
 				ifaddr_str);
@@ -230,7 +230,7 @@ void pim_igmp_other_querier_timer_on(struct igmp_sock *igmp)
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char ifaddr_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
+		pim_inet4_dump("<ifaddr?>", igmp->ifaddr.ipaddr_v4, ifaddr_str,
 			       sizeof(ifaddr_str));
 		zlog_debug(
 			"Querier %s scheduling %ld.%03ld sec TIMER event for Other-Querier-Present",
@@ -250,8 +250,8 @@ void pim_igmp_other_querier_timer_off(struct igmp_sock *igmp)
 	if (PIM_DEBUG_IGMP_TRACE) {
 		if (igmp->t_other_querier_timer) {
 			char ifaddr_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
-				       sizeof(ifaddr_str));
+			pim_inet4_dump("<ifaddr?>", igmp->ifaddr.ipaddr_v4,
+				       ifaddr_str, sizeof(ifaddr_str));
 			zlog_debug(
 				"IGMP querier %s fd=%d cancelling other-querier-present TIMER event on %s",
 				ifaddr_str, igmp->fd, igmp->interface->name);
@@ -374,21 +374,21 @@ static int igmp_recv_query(struct igmp_sock *igmp, int query_version,
 	  and ceases to send queries on the network if it was the previously
 	  elected querier.
 	 */
-	if (ntohl(from.s_addr) < ntohl(igmp->ifaddr.s_addr)) {
+	if (ntohl(from.s_addr) < ntohl(igmp->ifaddr.ipaddr_v4.s_addr)) {
 
 		if (PIM_DEBUG_IGMP_TRACE) {
 			char ifaddr_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
-				       sizeof(ifaddr_str));
+			pim_inet4_dump("<ifaddr?>", igmp->ifaddr.ipaddr_v4,
+				       ifaddr_str, sizeof(ifaddr_str));
 			zlog_debug(
 				"%s: local address %s (%u) lost querier election to %s (%u)",
 				ifp->name, ifaddr_str,
-				ntohl(igmp->ifaddr.s_addr), from_str,
+				ntohl(igmp->ifaddr.ipaddr_v4.s_addr), from_str,
 				ntohl(from.s_addr));
 		}
 		if (ntohl(from.s_addr)
-		    < ntohl(igmp->querier_addr.s_addr))
-			igmp->querier_addr.s_addr = from.s_addr;
+		    < ntohl(igmp->querier_addr.ipaddr_v4.s_addr))
+			igmp->querier_addr.ipaddr_v4.s_addr = from.s_addr;
 
 		pim_igmp_other_querier_timer_on(igmp);
 	}
@@ -652,8 +652,8 @@ void pim_igmp_general_query_on(struct igmp_sock *igmp)
 
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char ifaddr_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<ifaddr?>", igmp->ifaddr,
-			       ifaddr_str, sizeof(ifaddr_str));
+		pim_inet4_dump("<ifaddr?>", igmp->ifaddr.ipaddr_v4, ifaddr_str,
+			       sizeof(ifaddr_str));
 		zlog_debug(
 			"Querier %s scheduling %d-second (%s) TIMER event for IGMP query on fd=%d",
 			ifaddr_str, query_interval,
@@ -670,8 +670,8 @@ void pim_igmp_general_query_off(struct igmp_sock *igmp)
 	if (PIM_DEBUG_IGMP_TRACE) {
 		if (igmp->t_igmp_query_timer) {
 			char ifaddr_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
-				       sizeof(ifaddr_str));
+			pim_inet4_dump("<ifaddr?>", igmp->ifaddr.ipaddr_v4,
+				       ifaddr_str, sizeof(ifaddr_str));
 			zlog_debug(
 				"IGMP querier %s fd=%d cancelling query TIMER event on %s",
 				ifaddr_str, igmp->fd, igmp->interface->name);
@@ -719,8 +719,8 @@ static int pim_igmp_general_query(struct thread *t)
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char querier_str[INET_ADDRSTRLEN];
 		char dst_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<querier?>", igmp->ifaddr, querier_str,
-			       sizeof(querier_str));
+		pim_inet4_dump("<querier?>", igmp->ifaddr.ipaddr_v4,
+			       querier_str, sizeof(querier_str));
 		pim_inet4_dump("<dst?>", dst_addr, dst_str, sizeof(dst_str));
 		zlog_debug("Querier %s issuing IGMP general query to %s on %s",
 			   querier_str, dst_str, igmp->interface->name);
@@ -748,7 +748,7 @@ static void sock_close(struct igmp_sock *igmp)
 		if (igmp->t_igmp_read) {
 			zlog_debug(
 				"Cancelling READ event on IGMP socket %pI4 fd=%d on interface %s",
-				&igmp->ifaddr, igmp->fd,
+				&igmp->ifaddr.ipaddr_v4, igmp->fd,
 				igmp->interface->name);
 		}
 	}
@@ -758,13 +758,13 @@ static void sock_close(struct igmp_sock *igmp)
 		flog_err(
 			EC_LIB_SOCKET,
 			"Failure closing IGMP socket %pI4 fd=%d on interface %s: errno=%d: %s",
-			&igmp->ifaddr, igmp->fd,
+			&igmp->ifaddr.ipaddr_v4, igmp->fd,
 			igmp->interface->name, errno, safe_strerror(errno));
 	}
 
 	if (PIM_DEBUG_IGMP_TRACE_DETAIL) {
 		zlog_debug("Deleted IGMP socket %pI4 fd=%d on interface %s",
-			   &igmp->ifaddr, igmp->fd,
+			   &igmp->ifaddr.ipaddr_v4, igmp->fd,
 			   igmp->interface->name);
 	}
 }
@@ -972,8 +972,8 @@ static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 
 	igmp->fd = fd;
 	igmp->interface = ifp;
-	igmp->ifaddr = ifaddr;
-	igmp->querier_addr = ifaddr;
+	igmp->ifaddr.ipaddr_v4 = ifaddr;
+	igmp->querier_addr.ipaddr_v4 = ifaddr;
 	igmp->t_igmp_read = NULL;
 	igmp->t_igmp_query_timer = NULL;
 	igmp->t_other_querier_timer = NULL; /* no other querier present */

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -85,16 +85,16 @@ struct igmp_join {
 struct igmp_sock {
 	int fd;
 	struct interface *interface;
-	struct in_addr ifaddr;
+	struct ipaddr ifaddr;
 	time_t sock_creation;
 
 	struct thread *t_igmp_read; /* read: IGMP sockets */
 	struct thread
 		*t_igmp_query_timer; /* timer: issue IGMP general queries */
 	struct thread *t_other_querier_timer; /* timer: other querier present */
-	struct in_addr querier_addr;	  /* IP address of the querier */
+	struct ipaddr querier_addr;	   /* IP address of the querier */
 	int querier_query_interval;	   /* QQI */
-	int querier_robustness_variable; /* QRV */
+	int querier_robustness_variable;      /* QRV */
 	int startup_query_count;
 
 	bool mtrace_only;

--- a/pimd/pim_igmp_mtrace.c
+++ b/pimd/pim_igmp_mtrace.c
@@ -39,7 +39,7 @@ static struct in_addr mtrace_primary_address(struct interface *ifp)
 
 	if (ifp->info) {
 		pim_ifp = ifp->info;
-		return pim_ifp->primary_address;
+		return pim_ifp->primary_address.ipaddr_v4;
 	}
 
 	any.s_addr = INADDR_ANY;
@@ -214,8 +214,8 @@ static void mtrace_debug(struct pim_interface *pim_ifp,
 
 	zlog_debug(
 		"Rx mtrace packet incoming on %pI4: hops=%d type=%d size=%d, grp=%pI4, src=%pI4, dst=%pI4 rsp=%pI4 ttl=%d qid=%ud",
-		&pim_ifp->primary_address, mtracep->hops, mtracep->type,
-		mtrace_len, &ga, &sa, &da, &ra, mtracep->rsp_ttl,
+		&pim_ifp->primary_address.ipaddr_v4, mtracep->hops,
+		mtracep->type, mtrace_len, &ga, &sa, &da, &ra, mtracep->rsp_ttl,
 		ntohl(mtracep->qry_id));
 	if (mtrace_len > (int)sizeof(struct igmp_mtrace)) {
 
@@ -724,7 +724,7 @@ int igmp_mtrace_recv_qry_req(struct igmp_sock *igmp, struct ip *ip_hdr,
 
 	/* ...and fill in Query Arrival Time... */
 	rspp->arrival = htonl(query_arrival_time());
-	rspp->outgoing = pim_ifp->primary_address;
+	rspp->outgoing = pim_ifp->primary_address.ipaddr_v4;
 	rspp->out_count = htonl(MTRACE_UNKNOWN_COUNT);
 	rspp->fwd_ttl = 1;
 

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -1740,8 +1740,8 @@ void igmp_v3_recv_query(struct igmp_sock *igmp, const char *from_str,
 
 		if (PIM_DEBUG_IGMP_TRACE) {
 			char ifaddr_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
-				       sizeof(ifaddr_str));
+			pim_inet4_dump("<ifaddr?>", igmp->ifaddr.ipaddr_v4,
+				       ifaddr_str, sizeof(ifaddr_str));
 			zlog_debug(
 				"Querier %s new query interval is %s QQI=%u sec (recv QQIC=%02x from %s)",
 				ifaddr_str,

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -540,8 +540,8 @@ int pim_joinprune_send(struct pim_rpf *rpf, struct list *groups)
 			char grp_str[INET_ADDRSTRLEN];
 			pim_inet4_dump("<dst?>", rpf->rpf_addr.u.prefix4,
 				       dst_str, sizeof(dst_str));
-			pim_inet4_dump("<grp?>", group->group, grp_str,
-				       sizeof(grp_str));
+			pim_inet4_dump("<grp?>", group->group.ipaddr_v4,
+				       grp_str, sizeof(grp_str));
 			zlog_debug(
 				"%s: sending (G)=%s to upstream=%s on interface %s",
 				__func__, grp_str, dst_str,

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -553,7 +553,7 @@ int pim_joinprune_send(struct pim_rpf *rpf, struct list *groups)
 			pim_msg_build_header(pim_msg, packet_size,
 					     PIM_MSG_TYPE_JOIN_PRUNE, false);
 			if (pim_msg_send(pim_ifp->pim_sock_fd,
-					 pim_ifp->primary_address,
+					 pim_ifp->primary_address.ipaddr_v4,
 					 qpim_all_pim_routers_addr, pim_msg,
 					 packet_size,
 					 rpf->source_nexthop.interface->name)) {
@@ -609,7 +609,7 @@ int pim_joinprune_send(struct pim_rpf *rpf, struct list *groups)
 			pim_msg_build_header(pim_msg, packet_size,
 					     PIM_MSG_TYPE_JOIN_PRUNE, false);
 			if (pim_msg_send(pim_ifp->pim_sock_fd,
-					 pim_ifp->primary_address,
+					 pim_ifp->primary_address.ipaddr_v4,
 					 qpim_all_pim_routers_addr, pim_msg,
 					 packet_size,
 					 rpf->source_nexthop.interface->name)) {
@@ -628,7 +628,8 @@ int pim_joinprune_send(struct pim_rpf *rpf, struct list *groups)
 		// msg->num_groups = htons (msg->num_groups);
 		pim_msg_build_header(pim_msg, packet_size,
 				     PIM_MSG_TYPE_JOIN_PRUNE, false);
-		if (pim_msg_send(pim_ifp->pim_sock_fd, pim_ifp->primary_address,
+		if (pim_msg_send(pim_ifp->pim_sock_fd,
+				 pim_ifp->primary_address.ipaddr_v4,
 				 qpim_all_pim_routers_addr, pim_msg,
 				 packet_size,
 				 rpf->source_nexthop.interface->name)) {

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -63,8 +63,8 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 		char up_str[INET_ADDRSTRLEN];
 		char neigh_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<upstream?>", upstream, up_str, sizeof(up_str));
-		pim_inet4_dump("<neigh?>", neigh->source_addr, neigh_str,
-			       sizeof(neigh_str));
+		pim_inet4_dump("<neigh?>", neigh->source_addr.ipaddr_v4,
+			       neigh_str, sizeof(neigh_str));
 		zlog_debug(
 			"%s: join (S,G)=%s rpt=%d wc=%d upstream=%s holdtime=%d from %s on %s",
 			__func__, pim_str_sg_dump(sg),
@@ -119,7 +119,7 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 	}
 
 	/* Restart join expiry timer */
-	pim_ifchannel_join_add(ifp, neigh->source_addr, upstream, sg,
+	pim_ifchannel_join_add(ifp, neigh->source_addr.ipaddr_v4, upstream, sg,
 			       source_flags, holdtime);
 }
 
@@ -133,8 +133,8 @@ static void recv_prune(struct interface *ifp, struct pim_neighbor *neigh,
 		char up_str[INET_ADDRSTRLEN];
 		char neigh_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<upstream?>", upstream, up_str, sizeof(up_str));
-		pim_inet4_dump("<neigh?>", neigh->source_addr, neigh_str,
-			       sizeof(neigh_str));
+		pim_inet4_dump("<neigh?>", neigh->source_addr.ipaddr_v4,
+			       neigh_str, sizeof(neigh_str));
 		zlog_debug(
 			"%s: prune (S,G)=%s rpt=%d wc=%d upstream=%s holdtime=%d from %s on %s",
 			__func__, pim_str_sg_dump(sg),

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -98,8 +98,8 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 		if (sg->src.ipaddr_v4.s_addr != rp->rpf_addr.u.prefix4.s_addr) {
 			char received_rp[INET_ADDRSTRLEN];
 			char local_rp[INET_ADDRSTRLEN];
-			pim_inet4_dump("<received?>", sg->src.ipaddr_v4,
-				       received_rp, sizeof(received_rp));
+			pim_inet4_dump("<received?>", sg->src.ipaddr_v4, received_rp,
+				       sizeof(received_rp));
 			pim_inet4_dump("<local?>", rp->rpf_addr.u.prefix4,
 				       local_rp, sizeof(local_rp));
 			zlog_warn(
@@ -158,8 +158,8 @@ static void recv_prune(struct interface *ifp, struct pim_neighbor *neigh,
 		if (PIM_DEBUG_PIM_TRACE) {
 			char received_rp[INET_ADDRSTRLEN];
 
-			pim_inet4_dump("<received?>", sg->src.ipaddr_v4,
-				       received_rp, sizeof(received_rp));
+			pim_inet4_dump("<received?>", sg->src.ipaddr_v4, received_rp,
+				       sizeof(received_rp));
 			zlog_debug("%s: Prune received with RP(%s) for %pSG4",
 				   __func__, received_rp, sg);
 		}

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -60,10 +60,10 @@ int pim_jp_agg_group_list_cmp(void *arg1, void *arg2)
 	const struct pim_jp_agg_group *jag2 =
 		(const struct pim_jp_agg_group *)arg2;
 
-	if (jag1->group.s_addr < jag2->group.s_addr)
+	if (jag1->group.ipaddr_v4.s_addr < jag2->group.ipaddr_v4.s_addr)
 		return -1;
 
-	if (jag1->group.s_addr > jag2->group.s_addr)
+	if (jag1->group.ipaddr_v4.s_addr > jag2->group.ipaddr_v4.s_addr)
 		return 1;
 
 	return 0;
@@ -159,7 +159,7 @@ void pim_jp_agg_remove_group(struct list *group, struct pim_upstream *up,
 	struct pim_jp_sources *js = NULL;
 
 	for (ALL_LIST_ELEMENTS(group, node, nnode, jag)) {
-		if (jag->group.s_addr == up->sg.grp.ipaddr_v4.s_addr)
+		if (jag->group.ipaddr_v4.s_addr == up->sg.grp.ipaddr_v4.s_addr)
 			break;
 	}
 
@@ -202,8 +202,7 @@ int pim_jp_agg_is_in_list(struct list *group, struct pim_upstream *up)
 	struct pim_jp_sources *js = NULL;
 
 	for (ALL_LIST_ELEMENTS(group, node, nnode, jag)) {
-		if (jag->group.s_addr
-		    == up->sg.grp.ipaddr_v4.s_addr)
+		if (jag->group.ipaddr_v4.s_addr == up->sg.grp.ipaddr_v4.s_addr)
 			break;
 	}
 
@@ -277,14 +276,14 @@ void pim_jp_agg_add_group(struct list *group, struct pim_upstream *up,
 	struct pim_jp_sources *js = NULL;
 
 	for (ALL_LIST_ELEMENTS(group, node, nnode, jag)) {
-		if (jag->group.s_addr == up->sg.grp.ipaddr_v4.s_addr)
+		if (jag->group.ipaddr_v4.s_addr == up->sg.grp.ipaddr_v4.s_addr)
 			break;
 	}
 
 	if (!jag) {
 		jag = XCALLOC(MTYPE_PIM_JP_AGG_GROUP,
 			      sizeof(struct pim_jp_agg_group));
-		jag->group.s_addr = up->sg.grp.ipaddr_v4.s_addr;
+		jag->group.ipaddr_v4.s_addr = up->sg.grp.ipaddr_v4.s_addr;
 		jag->sources = list_new();
 		jag->sources->cmp = pim_jp_agg_src_cmp;
 		jag->sources->del = (void (*)(void *))pim_jp_agg_src_free;
@@ -378,7 +377,7 @@ void pim_jp_agg_single_upstream_send(struct pim_rpf *rpf,
 	listnode_add(&groups, &jag);
 	listnode_add(jag.sources, &js);
 
-	jag.group.s_addr = up->sg.grp.ipaddr_v4.s_addr;
+	jag.group.ipaddr_v4.s_addr = up->sg.grp.ipaddr_v4.s_addr;
 	js.up = up;
 	js.is_join = is_join;
 

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -175,13 +175,10 @@ void pim_jp_agg_remove_group(struct list *group, struct pim_upstream *up,
 		if (PIM_DEBUG_TRACE) {
 			char src_str[INET_ADDRSTRLEN];
 
-			pim_inet4_dump("<src?>", nbr->source_addr, src_str,
-					sizeof(src_str));
-			zlog_debug(
-				"up %s remove from nbr %s/%s jp-agg-list",
-				up->sg_str,
-				nbr->interface->name,
-				src_str);
+			pim_inet4_dump("<src?>", nbr->source_addr.ipaddr_v4,
+				       src_str, sizeof(src_str));
+			zlog_debug("up %s remove from nbr %s/%s jp-agg-list",
+				   up->sg_str, nbr->interface->name, src_str);
 		}
 	}
 
@@ -303,13 +300,12 @@ void pim_jp_agg_add_group(struct list *group, struct pim_upstream *up,
 		if (PIM_DEBUG_TRACE) {
 			char src_str[INET_ADDRSTRLEN];
 
-			pim_inet4_dump("<src?>", nbr->source_addr, src_str,
-					sizeof(src_str));
-			zlog_debug(
-				"up %s add to nbr %s/%s jp-agg-list",
-				up->sg_str,
-				up->rpf.source_nexthop.interface->name,
-				src_str);
+			pim_inet4_dump("<src?>", nbr->source_addr.ipaddr_v4,
+				       src_str, sizeof(src_str));
+			zlog_debug("up %s add to nbr %s/%s jp-agg-list",
+				   up->sg_str,
+				   up->rpf.source_nexthop.interface->name,
+				   src_str);
 		}
 	}
 

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -205,7 +205,8 @@ int pim_jp_agg_is_in_list(struct list *group, struct pim_upstream *up)
 	struct pim_jp_sources *js = NULL;
 
 	for (ALL_LIST_ELEMENTS(group, node, nnode, jag)) {
-		if (jag->group.s_addr == up->sg.grp.ipaddr_v4.s_addr)
+		if (jag->group.s_addr
+		    == up->sg.grp.ipaddr_v4.s_addr)
 			break;
 	}
 

--- a/pimd/pim_jp_agg.h
+++ b/pimd/pim_jp_agg.h
@@ -26,7 +26,7 @@ struct pim_jp_sources {
 };
 
 struct pim_jp_agg_group {
-	struct in_addr group;
+	struct ipaddr group;
 	struct list *sources;
 };
 

--- a/pimd/pim_macro.c
+++ b/pimd/pim_macro.c
@@ -133,11 +133,11 @@ int pim_macro_ch_lost_assert(const struct pim_ifchannel *ch)
 
 	/* AssertWinner(S,G,I) == me ? */
 	if (ch->ifassert_winner.ipaddr_v4.s_addr
-	    == pim_ifp->primary_address.s_addr)
+	    == pim_ifp->primary_address.ipaddr_v4.s_addr)
 		return 0; /* false */
 
 	spt_assert_metric = pim_macro_spt_assert_metric(
-		&ch->upstream->rpf, pim_ifp->primary_address);
+		&ch->upstream->rpf, pim_ifp->primary_address.ipaddr_v4);
 
 	return pim_assert_metric_better(&ch->ifassert_winner_metric,
 					&spt_assert_metric);
@@ -172,7 +172,7 @@ int pim_macro_chisin_pim_include(const struct pim_ifchannel *ch)
 
 	/* OR AssertWinner(S,G,I) == me ? */
 	if (ch->ifassert_winner.ipaddr_v4.s_addr
-	    == pim_ifp->primary_address.s_addr)
+	    == pim_ifp->primary_address.ipaddr_v4.s_addr)
 		return 1; /* true */
 
 	/*
@@ -303,7 +303,7 @@ pim_macro_ch_my_assert_metric_eval(const struct pim_ifchannel *ch)
 		if (PIM_IF_FLAG_TEST_COULD_ASSERT(ch->flags)) {
 			return pim_macro_spt_assert_metric(
 				&ch->upstream->rpf,
-				pim_ifp->primary_address);
+				pim_ifp->primary_address.ipaddr_v4);
 		}
 	}
 
@@ -416,7 +416,7 @@ int pim_macro_assert_tracking_desired_eval(const struct pim_ifchannel *ch)
 
 		/* AssertWinner(S,G,I) == me ? */
 		if (ch->ifassert_winner.ipaddr_v4.s_addr
-		    == pim_ifp->primary_address.s_addr)
+		    == pim_ifp->primary_address.ipaddr_v4.s_addr)
 			return 1; /* true */
 	}
 

--- a/pimd/pim_macro.c
+++ b/pimd/pim_macro.c
@@ -302,7 +302,8 @@ pim_macro_ch_my_assert_metric_eval(const struct pim_ifchannel *ch)
 	if (pim_ifp) {
 		if (PIM_IF_FLAG_TEST_COULD_ASSERT(ch->flags)) {
 			return pim_macro_spt_assert_metric(
-				&ch->upstream->rpf, pim_ifp->primary_address);
+				&ch->upstream->rpf,
+				pim_ifp->primary_address);
 		}
 	}
 

--- a/pimd/pim_mlag.c
+++ b/pimd/pim_mlag.c
@@ -174,8 +174,8 @@ bool pim_mlag_up_df_role_update(struct pim_instance *pim,
 	/* If DF role changed on a (*,G) termination mroute update the
 	 * associated DF role on the inherited (S,G) entries
 	 */
-	if ((up->sg.src.ipaddr_v4.s_addr == INADDR_ANY)
-	    && PIM_UPSTREAM_FLAG_TEST_MLAG_VXLAN(up->flags))
+	if ((up->sg.src.ipaddr_v4.s_addr == INADDR_ANY) &&
+			PIM_UPSTREAM_FLAG_TEST_MLAG_VXLAN(up->flags))
 		pim_vxlan_inherit_mlag_flags(pim, up, true /* inherit */);
 
 	return true;

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -519,12 +519,14 @@ static int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp,
 			 * bow out of doing a nexthop lookup and
 			 * setting the SPTBIT to true
 			 */
-			if (up->upstream_register.s_addr != INADDR_ANY &&
-			    pim_nexthop_lookup(pim_ifp->pim, &source,
-					       up->upstream_register, 0)) {
-				pim_register_stop_send(source.interface, &sg,
-						       pim_ifp->primary_address,
-						       up->upstream_register);
+			if (up->upstream_register.ipaddr_v4.s_addr != INADDR_ANY
+			    && pim_nexthop_lookup(
+				       pim_ifp->pim, &source,
+				       up->upstream_register.ipaddr_v4, 0)) {
+				pim_register_stop_send(
+					source.interface, &sg,
+					pim_ifp->primary_address,
+					up->upstream_register.ipaddr_v4);
 				up->sptbit = PIM_UPSTREAM_SPTBIT_TRUE;
 			}
 
@@ -534,13 +536,13 @@ static int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp,
 							__func__);
 		} else {
 			if (I_am_RP(pim_ifp->pim, up->sg.grp.ipaddr_v4)) {
-				if (pim_nexthop_lookup(pim_ifp->pim, &source,
-						       up->upstream_register,
-						       0))
+				if (pim_nexthop_lookup(
+					    pim_ifp->pim, &source,
+					    up->upstream_register.ipaddr_v4, 0))
 					pim_register_stop_send(
 						source.interface, &sg,
 						pim_ifp->primary_address,
-						up->upstream_register);
+						up->upstream_register.ipaddr_v4);
 				up->sptbit = PIM_UPSTREAM_SPTBIT_TRUE;
 			}
 			pim_upstream_keep_alive_timer_start(

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -332,7 +332,8 @@ static int pim_mroute_msg_wholepkt(int fd, struct interface *ifp,
 
 		pim_register_send((uint8_t *)buf + sizeof(struct ip),
 				  ntohs(ip_hdr->ip_len) - sizeof(struct ip),
-				  pim_ifp->primary_address, rpg, 0, up);
+				  pim_ifp->primary_address.ipaddr_v4, rpg, 0,
+				  up);
 	}
 	return 0;
 }
@@ -525,7 +526,7 @@ static int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp,
 				       up->upstream_register.ipaddr_v4, 0)) {
 				pim_register_stop_send(
 					source.interface, &sg,
-					pim_ifp->primary_address,
+					pim_ifp->primary_address.ipaddr_v4,
 					up->upstream_register.ipaddr_v4);
 				up->sptbit = PIM_UPSTREAM_SPTBIT_TRUE;
 			}
@@ -541,8 +542,10 @@ static int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp,
 					    up->upstream_register.ipaddr_v4, 0))
 					pim_register_stop_send(
 						source.interface, &sg,
-						pim_ifp->primary_address,
-						up->upstream_register.ipaddr_v4);
+						pim_ifp->primary_address
+							.ipaddr_v4,
+						up->upstream_register
+							.ipaddr_v4);
 				up->sptbit = PIM_UPSTREAM_SPTBIT_TRUE;
 			}
 			pim_upstream_keep_alive_timer_start(

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -662,7 +662,8 @@ static void pim_msdp_up_xg_del(struct pim_instance *pim, struct prefix_sg *sg)
 	/* XXX: Need to maintain SAs per-group to avoid all this unnecessary
 	 * walking */
 	for (ALL_LIST_ELEMENTS_RO(pim->msdp.sa_list, sanode, sa)) {
-		if (sa->sg.grp.ipaddr_v4.s_addr != sg->grp.ipaddr_v4.s_addr) {
+		if (sa->sg.grp.ipaddr_v4.s_addr
+		    != sg->grp.ipaddr_v4.s_addr) {
 			continue;
 		}
 		pim_msdp_sa_upstream_update(sa, NULL /* xg */, "up-jp-change");
@@ -695,7 +696,8 @@ static bool pim_msdp_sa_hash_eq(const void *p1, const void *p2)
 	const struct pim_msdp_sa *sa1 = p1;
 	const struct pim_msdp_sa *sa2 = p2;
 
-	return ((sa1->sg.src.ipaddr_v4.s_addr == sa2->sg.src.ipaddr_v4.s_addr)
+	return ((sa1->sg.src.ipaddr_v4.s_addr
+		 == sa2->sg.src.ipaddr_v4.s_addr)
 		&& (sa1->sg.grp.ipaddr_v4.s_addr
 		    == sa2->sg.grp.ipaddr_v4.s_addr));
 }

--- a/pimd/pim_msg.c
+++ b/pimd/pim_msg.c
@@ -185,7 +185,8 @@ size_t pim_msg_build_jp_groups(struct pim_jp_groups *grp,
 	uint8_t tgroups = 0;
 
 	memset(grp, 0, size);
-	pim_msg_addr_encode_ipv4_group((uint8_t *)&grp->g, sgs->group);
+	pim_msg_addr_encode_ipv4_group((uint8_t *)&grp->g,
+				       sgs->group.ipaddr_v4);
 
 	for (ALL_LIST_ELEMENTS(sgs->sources, node, nnode, source)) {
 		/* number of joined/pruned sources */

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -380,8 +380,8 @@ static void igmp_sock_query_interval_reconfig(struct igmp_sock *igmp)
 	if (PIM_DEBUG_IGMP_TRACE) {
 		char ifaddr_str[INET_ADDRSTRLEN];
 
-		pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
-				sizeof(ifaddr_str));
+		pim_inet4_dump("<ifaddr?>", igmp->ifaddr.ipaddr_v4, ifaddr_str,
+			       sizeof(ifaddr_str));
 		zlog_debug("%s: Querier %s on %s reconfig query_interval=%d",
 			   __func__, ifaddr_str, ifp->name,
 			   pim_ifp->default_query_interval);

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2818,7 +2818,7 @@ int lib_interface_igmp_address_family_static_group_destroy(
 		yang_dnode_get_ip(&group_addr, args->dnode, "./group-addr");
 
 		result = pim_if_igmp_join_del(ifp, group_addr.ipaddr_v4,
-					      source_addr.ipaddr_v4);
+				source_addr.ipaddr_v4);
 
 		if (result) {
 			char src_str[INET_ADDRSTRLEN];

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -58,9 +58,10 @@ static void dr_election_by_addr(struct interface *ifp)
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(pim_ifp->pim_neighbor_list, node, neigh)) {
-		if (ntohl(neigh->source_addr.s_addr)
+		if (ntohl(neigh->source_addr.ipaddr_v4.s_addr)
 		    > ntohl(pim_ifp->pim_dr_addr.ipaddr_v4.s_addr)) {
-			pim_ifp->pim_dr_addr.ipaddr_v4 = neigh->source_addr;
+			pim_ifp->pim_dr_addr.ipaddr_v4 =
+				neigh->source_addr.ipaddr_v4;
 		}
 	}
 }
@@ -87,14 +88,15 @@ static void dr_election_by_pri(struct interface *ifp)
 		if (PIM_DEBUG_PIM_TRACE) {
 			zlog_info("%s: neigh pri %u addr %x if dr addr %x",
 				  __func__, neigh->dr_priority,
-				  ntohl(neigh->source_addr.s_addr),
+				  ntohl(neigh->source_addr.ipaddr_v4.s_addr),
 				  ntohl(pim_ifp->pim_dr_addr.ipaddr_v4.s_addr));
 		}
 		if ((neigh->dr_priority > dr_pri)
 		    || ((neigh->dr_priority == dr_pri)
-			&& (ntohl(neigh->source_addr.s_addr)
+			&& (ntohl(neigh->source_addr.ipaddr_v4.s_addr)
 			    > ntohl(pim_ifp->pim_dr_addr.ipaddr_v4.s_addr)))) {
-			pim_ifp->pim_dr_addr.ipaddr_v4 = neigh->source_addr;
+			pim_ifp->pim_dr_addr.ipaddr_v4 =
+				neigh->source_addr.ipaddr_v4;
 			dr_pri = neigh->dr_priority;
 		}
 	}
@@ -221,7 +223,7 @@ static int on_neighbor_timer(struct thread *t)
 
 	if (PIM_DEBUG_PIM_TRACE) {
 		char src_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<src?>", neigh->source_addr, src_str,
+		pim_inet4_dump("<src?>", neigh->source_addr.ipaddr_v4, src_str,
 			       sizeof(src_str));
 		zlog_debug(
 			"Expired %d sec holdtime for neighbor %s on interface %s",
@@ -258,8 +260,8 @@ void pim_neighbor_timer_reset(struct pim_neighbor *neigh, uint16_t holdtime)
 
 	if (PIM_DEBUG_PIM_TRACE_DETAIL) {
 		char src_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<src?>", neigh->source_addr,
-			       src_str, sizeof(src_str));
+		pim_inet4_dump("<src?>", neigh->source_addr.ipaddr_v4, src_str,
+			       sizeof(src_str));
 		zlog_debug("%s: starting %u sec timer for neighbor %s on %s",
 			   __func__, neigh->holdtime, src_str,
 			   neigh->interface->name);
@@ -276,15 +278,15 @@ static int on_neighbor_jp_timer(struct thread *t)
 
 	if (PIM_DEBUG_PIM_TRACE) {
 		char src_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<src?>", neigh->source_addr,
-			       src_str, sizeof(src_str));
+		pim_inet4_dump("<src?>", neigh->source_addr.ipaddr_v4, src_str,
+			       sizeof(src_str));
 		zlog_debug("%s:Sending JP Agg to %s on %s with %d groups",
 			   __func__, src_str, neigh->interface->name,
 			   neigh->upstream_jp_agg->count);
 	}
 
 	rpf.source_nexthop.interface = neigh->interface;
-	rpf.rpf_addr.u.prefix4 = neigh->source_addr;
+	rpf.rpf_addr.u.prefix4 = neigh->source_addr.ipaddr_v4;
 	pim_joinprune_send(&rpf, neigh->upstream_jp_agg);
 
 	thread_add_timer(router->master, on_neighbor_jp_timer, neigh,
@@ -318,7 +320,7 @@ pim_neighbor_new(struct interface *ifp, struct in_addr source_addr,
 	neigh = XCALLOC(MTYPE_PIM_NEIGHBOR, sizeof(*neigh));
 
 	neigh->creation = pim_time_monotonic_sec();
-	neigh->source_addr = source_addr;
+	neigh->source_addr.ipaddr_v4 = source_addr;
 	neigh->hello_options = hello_options;
 	neigh->propagation_delay_msec = propagation_delay;
 	neigh->override_interval_msec = override_interval;
@@ -463,7 +465,7 @@ struct pim_neighbor *pim_neighbor_find(struct interface *ifp,
 		return NULL;
 
 	for (ALL_LIST_ELEMENTS_RO(pim_ifp->pim_neighbor_list, node, neigh)) {
-		if (source_addr.s_addr == neigh->source_addr.s_addr) {
+		if (source_addr.s_addr == neigh->source_addr.ipaddr_v4.s_addr) {
 			return neigh;
 		}
 	}
@@ -616,13 +618,14 @@ void pim_neighbor_delete(struct interface *ifp, struct pim_neighbor *neigh,
 	pim_ifp = ifp->info;
 	assert(pim_ifp);
 
-	pim_inet4_dump("<src?>", neigh->source_addr, src_str, sizeof(src_str));
+	pim_inet4_dump("<src?>", neigh->source_addr.ipaddr_v4, src_str,
+		       sizeof(src_str));
 	zlog_notice("PIM NEIGHBOR DOWN: neighbor %s on interface %s: %s",
 		    src_str, ifp->name, delete_message);
 
 	THREAD_OFF(neigh->t_expire_timer);
 
-	pim_if_assert_on_neighbor_down(ifp, neigh->source_addr);
+	pim_if_assert_on_neighbor_down(ifp, neigh->source_addr.ipaddr_v4);
 
 	if (!PIM_OPTION_IS_SET(neigh->hello_options,
 			       PIM_OPTION_MASK_LAN_PRUNE_DELAY)) {
@@ -762,10 +765,11 @@ static void delete_from_neigh_addr(struct interface *ifp,
 					pim_inet4_dump("<neigh1?>", neigh_addr,
 						       this_neigh_str,
 						       sizeof(this_neigh_str));
-					pim_inet4_dump("<neigh2?>",
-						       neigh->source_addr,
-						       other_neigh_str,
-						       sizeof(other_neigh_str));
+					pim_inet4_dump(
+						"<neigh2?>",
+						neigh->source_addr.ipaddr_v4,
+						other_neigh_str,
+						sizeof(other_neigh_str));
 
 					zlog_info(
 						"secondary addr %s recvd from neigh %s deleted from neigh %s on %s",
@@ -820,7 +824,7 @@ void pim_neighbor_update(struct pim_neighbor *neigh,
 
 	if (addr_list) {
 		delete_from_neigh_addr(neigh->interface, addr_list,
-				       neigh->source_addr);
+				       neigh->source_addr.ipaddr_v4);
 	}
 
 	/* Replace secondary address list */

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -257,8 +257,8 @@ void pim_neighbor_timer_reset(struct pim_neighbor *neigh, uint16_t holdtime)
 
 	if (PIM_DEBUG_PIM_TRACE_DETAIL) {
 		char src_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<src?>", neigh->source_addr, src_str,
-			       sizeof(src_str));
+		pim_inet4_dump("<src?>", neigh->source_addr,
+			       src_str, sizeof(src_str));
 		zlog_debug("%s: starting %u sec timer for neighbor %s on %s",
 			   __func__, neigh->holdtime, src_str,
 			   neigh->interface->name);
@@ -275,8 +275,8 @@ static int on_neighbor_jp_timer(struct thread *t)
 
 	if (PIM_DEBUG_PIM_TRACE) {
 		char src_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<src?>", neigh->source_addr, src_str,
-			       sizeof(src_str));
+		pim_inet4_dump("<src?>", neigh->source_addr,
+			       src_str, sizeof(src_str));
 		zlog_debug("%s:Sending JP Agg to %s on %s with %d groups",
 			   __func__, src_str, neigh->interface->name,
 			   neigh->upstream_jp_agg->count);

--- a/pimd/pim_neighbor.h
+++ b/pimd/pim_neighbor.h
@@ -31,7 +31,7 @@
 
 struct pim_neighbor {
 	int64_t creation; /* timestamp of creation */
-	struct in_addr source_addr;
+	struct ipaddr source_addr;
 	pim_hello_options hello_options;
 	uint16_t holdtime;
 	uint16_t propagation_delay_msec;

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -672,7 +672,7 @@ static int pim_ecmp_nexthop_search(struct pim_instance *pim,
 				nh_node->gate.ipv4;
 			nexthop->mrib_metric_preference = pnc->distance;
 			nexthop->mrib_route_metric = pnc->metric;
-			nexthop->last_lookup = src->u.prefix4;
+			nexthop->last_lookup.ipaddr_v4 = src->u.prefix4;
 			nexthop->last_lookup_time = pim_time_monotonic_usec();
 			nexthop->nbr = nbr;
 			found = 1;
@@ -1037,7 +1037,7 @@ int pim_ecmp_nexthop_lookup(struct pim_instance *pim,
 				nexthop_tab[i].protocol_distance;
 			nexthop->mrib_route_metric =
 				nexthop_tab[i].route_metric;
-			nexthop->last_lookup = src->u.prefix4;
+			nexthop->last_lookup.ipaddr_v4 = src->u.prefix4;
 			nexthop->last_lookup_time = pim_time_monotonic_usec();
 			nexthop->nbr = nbr;
 			found = 1;

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -781,7 +781,8 @@ int pim_parse_nexthop_update(ZAPI_CALLBACK_ARGS)
 					nbr = pim_neighbor_find_if(ifp1);
 				/* Overwrite with Nbr address as NH addr */
 				if (nbr)
-					nexthop->gate.ipv4 = nbr->source_addr;
+					nexthop->gate.ipv4 =
+						nbr->source_addr.ipaddr_v4;
 				else {
 					// Mark nexthop address to 0 until PIM
 					// Nbr is resolved.

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -329,8 +329,8 @@ void pim_channel_del_inherited_oif(struct channel_oil *c_oil,
 	/* if an inherited OIF is being removed join-desired can change
 	 * if the inherited OIL is now empty and KAT is running
 	 */
-	if (up && up->sg.src.ipaddr_v4.s_addr != INADDR_ANY
-	    && pim_upstream_empty_inherited_olist(up))
+	if (up && up->sg.src.ipaddr_v4.s_addr != INADDR_ANY &&
+			pim_upstream_empty_inherited_olist(up))
 		pim_upstream_update_join_desired(up->pim, up);
 }
 

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -424,13 +424,13 @@ static int pim_sock_open(struct interface *ifp)
 	int fd;
 	struct pim_interface *pim_ifp = ifp->info;
 
-	fd = pim_socket_mcast(IPPROTO_PIM, pim_ifp->primary_address, ifp,
-			      0 /* loop=false */);
+	fd = pim_socket_mcast(IPPROTO_PIM, pim_ifp->primary_address.ipaddr_v4,
+			      ifp, 0 /* loop=false */);
 	if (fd < 0)
 		return -1;
 
 	if (pim_socket_join(fd, qpim_all_pim_routers_addr,
-			    pim_ifp->primary_address, ifp->ifindex)) {
+			    pim_ifp->primary_address.ipaddr_v4, ifp->ifindex)) {
 		close(fd);
 		return -2;
 	}
@@ -480,7 +480,7 @@ void pim_sock_reset(struct interface *ifp)
 
 	pim_ifp = ifp->info;
 
-	pim_ifp->primary_address = pim_find_primary_addr(ifp);
+	pim_ifp->primary_address.ipaddr_v4 = pim_find_primary_addr(ifp);
 
 	pim_ifp->pim_sock_fd = -1;
 	pim_ifp->pim_sock_creation = 0;
@@ -513,7 +513,7 @@ void pim_sock_reset(struct interface *ifp)
 	pim_ifp->pim_dr_election_changes = 0;
 	pim_ifp->pim_dr_num_nondrpri_neighbors =
 		0; /* neighbors without dr_pri */
-	pim_ifp->pim_dr_addr = pim_ifp->primary_address;
+	pim_ifp->pim_dr_addr.ipaddr_v4 = pim_ifp->primary_address.ipaddr_v4;
 	pim_ifp->am_i_dr = true;
 
 	pim_ifstat_reset(ifp);
@@ -689,7 +689,8 @@ static int hello_send(struct interface *ifp, uint16_t holdtime)
 
 	pim_msg_build_header(pim_msg, pim_msg_size, PIM_MSG_TYPE_HELLO, false);
 
-	if (pim_msg_send(pim_ifp->pim_sock_fd, pim_ifp->primary_address,
+	if (pim_msg_send(pim_ifp->pim_sock_fd,
+			 pim_ifp->primary_address.ipaddr_v4,
 			 qpim_all_pim_routers_addr, pim_msg, pim_msg_size,
 			 ifp->name)) {
 		if (PIM_DEBUG_PIM_HELLO) {

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -254,7 +254,7 @@ void pim_null_register_send(struct pim_upstream *up)
 	ip_hdr.ip_len = htons(20);
 
 	/* checksum is broken */
-	src = pim_ifp->primary_address;
+	src = pim_ifp->primary_address.ipaddr_v4;
 	if (PIM_UPSTREAM_FLAG_TEST_SRC_VXLAN_ORIG(up->flags)) {
 		if (!pim_vxlan_get_register_src(pim_ifp->pim, up, &src)) {
 			if (PIM_DEBUG_PIM_TRACE)

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -458,7 +458,7 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 				return 1;
 			}
 
-			upstream->upstream_register = src_addr;
+			upstream->upstream_register.ipaddr_v4 = src_addr;
 		} else {
 			/*
 			 * If the FHR has set a very very fast register timer

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -324,7 +324,7 @@ static int pim_rp_check_interface_addrs(struct rp_info *rp_info,
 	struct listnode *node;
 	struct pim_secondary_addr *sec_addr;
 
-	if (pim_ifp->primary_address.s_addr
+	if (pim_ifp->primary_address.ipaddr_v4.s_addr
 	    == rp_info->rp.rpf_addr.u.prefix4.s_addr)
 		return 1;
 

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -368,7 +368,8 @@ void pim_upstream_update(struct pim_instance *pim, struct pim_upstream *up)
 	struct prefix nht_p;
 
 	old_upstream_addr = up->upstream_addr;
-	pim_rp_set_upstream_addr(pim, &new_upstream_addr, up->sg.src.ipaddr_v4,
+	pim_rp_set_upstream_addr(pim, &new_upstream_addr,
+				 up->sg.src.ipaddr_v4,
 				 up->sg.grp.ipaddr_v4);
 
 	if (PIM_DEBUG_PIM_TRACE)
@@ -538,8 +539,7 @@ int pim_rp_new(struct pim_instance *pim, struct in_addr rp_addr,
 				 * configured yet
 				 */
 				if ((up->upstream_addr.s_addr == INADDR_ANY)
-				    && (up->sg.src.ipaddr_v4.s_addr
-					== INADDR_ANY)) {
+				    && (up->sg.src.ipaddr_v4.s_addr == INADDR_ANY)) {
 					struct prefix grp;
 					struct rp_info *trp_info;
 
@@ -842,10 +842,9 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 			/* RP not found for the group grp */
 			if (pim_rpf_addr_is_inaddr_none(&trp_info->rp)) {
 				pim_upstream_rpf_clear(pim, up);
-				pim_rp_set_upstream_addr(pim,
-							 &up->upstream_addr,
-							 up->sg.src.ipaddr_v4,
-							 up->sg.grp.ipaddr_v4);
+				pim_rp_set_upstream_addr(
+					pim, &up->upstream_addr, up->sg.src.ipaddr_v4,
+					up->sg.grp.ipaddr_v4);
 			}
 
 			/* RP found for the group grp */

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -1357,12 +1357,13 @@ void pim_resolve_rp_nh(struct pim_instance *pim, struct pim_neighbor *nbr)
 			if (nbr->interface != ifp1)
 				continue;
 
-			nh_node->gate.ipv4 = nbr->source_addr;
+			nh_node->gate.ipv4 = nbr->source_addr.ipaddr_v4;
 			if (PIM_DEBUG_PIM_NHT_RP) {
 				char str[PREFIX_STRLEN];
 				char str1[INET_ADDRSTRLEN];
-				pim_inet4_dump("<nht_nbr?>", nbr->source_addr,
-					       str1, sizeof(str1));
+				pim_inet4_dump("<nht_nbr?>",
+					       nbr->source_addr.ipaddr_v4, str1,
+					       sizeof(str1));
 				pim_addr_dump("<nht_addr?>", &nht_p, str,
 					      sizeof(str));
 				zlog_debug(

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -367,7 +367,7 @@ void pim_upstream_update(struct pim_instance *pim, struct pim_upstream *up)
 	struct in_addr new_upstream_addr;
 	struct prefix nht_p;
 
-	old_upstream_addr = up->upstream_addr;
+	old_upstream_addr = up->upstream_addr.ipaddr_v4;
 	pim_rp_set_upstream_addr(pim, &new_upstream_addr,
 				 up->sg.src.ipaddr_v4,
 				 up->sg.grp.ipaddr_v4);
@@ -397,7 +397,7 @@ void pim_upstream_update(struct pim_instance *pim, struct pim_upstream *up)
 	}
 
 	/* Update the upstream address */
-	up->upstream_addr = new_upstream_addr;
+	up->upstream_addr.ipaddr_v4 = new_upstream_addr;
 
 	old_rpf.source_nexthop.interface = up->rpf.source_nexthop.interface;
 
@@ -538,7 +538,8 @@ int pim_rp_new(struct pim_instance *pim, struct in_addr rp_addr,
 				/* Find (*, G) upstream whose RP is not
 				 * configured yet
 				 */
-				if ((up->upstream_addr.s_addr == INADDR_ANY)
+				if ((up->upstream_addr.ipaddr_v4.s_addr
+				     == INADDR_ANY)
 				    && (up->sg.src.ipaddr_v4.s_addr == INADDR_ANY)) {
 					struct prefix grp;
 					struct rp_info *trp_info;
@@ -780,7 +781,7 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 			/* Find the upstream (*, G) whose upstream address is
 			 * same as the deleted RP
 			 */
-			if ((up->upstream_addr.s_addr
+			if ((up->upstream_addr.ipaddr_v4.s_addr
 			     == rp_info->rp.rpf_addr.u.prefix4.s_addr)
 			    && (up->sg.src.ipaddr_v4.s_addr == INADDR_ANY)) {
 				struct prefix grp;
@@ -790,7 +791,8 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 				trp_info = pim_rp_find_match_group(pim, &grp);
 				if (trp_info == rp_all) {
 					pim_upstream_rpf_clear(pim, up);
-					up->upstream_addr.s_addr = INADDR_ANY;
+					up->upstream_addr.ipaddr_v4.s_addr =
+						INADDR_ANY;
 				}
 			}
 		}
@@ -828,7 +830,7 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 		/* Find the upstream (*, G) whose upstream address is same as
 		 * the deleted RP
 		 */
-		if ((up->upstream_addr.s_addr
+		if ((up->upstream_addr.ipaddr_v4.s_addr
 		     == rp_info->rp.rpf_addr.u.prefix4.s_addr)
 		    && (up->sg.src.ipaddr_v4.s_addr == INADDR_ANY)) {
 			struct prefix grp;
@@ -843,8 +845,8 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 			if (pim_rpf_addr_is_inaddr_none(&trp_info->rp)) {
 				pim_upstream_rpf_clear(pim, up);
 				pim_rp_set_upstream_addr(
-					pim, &up->upstream_addr, up->sg.src.ipaddr_v4,
-					up->sg.grp.ipaddr_v4);
+					pim, &up->upstream_addr.ipaddr_v4,
+					up->sg.src.ipaddr_v4, up->sg.grp.ipaddr_v4);
 			}
 
 			/* RP found for the group grp */

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -234,9 +234,9 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 	if (PIM_UPSTREAM_FLAG_TEST_STATIC_IIF(up->flags))
 		return PIM_RPF_OK;
 
-	if (up->upstream_addr.s_addr == INADDR_ANY) {
-		zlog_debug("%s(%s): RP is not configured yet for %s",
-			__func__, caller, up->sg_str);
+	if (up->upstream_addr.ipaddr_v4.s_addr == INADDR_ANY) {
+		zlog_debug("%s(%s): RP is not configured yet for %s", __func__,
+			   caller, up->sg_str);
 		return PIM_RPF_OK;
 	}
 
@@ -250,11 +250,11 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 
 	nht_p.family = AF_INET;
 	nht_p.prefixlen = IPV4_MAX_BITLEN;
-	nht_p.u.prefix4.s_addr = up->upstream_addr.s_addr;
+	nht_p.u.prefix4.s_addr = up->upstream_addr.ipaddr_v4.s_addr;
 
 	src.family = AF_INET;
 	src.prefixlen = IPV4_MAX_BITLEN;
-	src.u.prefix4 = up->upstream_addr; // RP or Src address
+	src.u.prefix4 = up->upstream_addr.ipaddr_v4; // RP or Src address
 	grp.family = AF_INET;
 	grp.prefixlen = IPV4_MAX_BITLEN;
 	grp.u.prefix4 = up->sg.grp.ipaddr_v4;

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -69,7 +69,7 @@ bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
 	if (addr.s_addr == INADDR_NONE)
 		return false;
 
-	if ((nexthop->last_lookup.s_addr == addr.s_addr)
+	if ((nexthop->last_lookup.ipaddr_v4.s_addr == addr.s_addr)
 	    && (nexthop->last_lookup_time > pim->last_route_change_time)) {
 		if (PIM_DEBUG_PIM_NHT) {
 			char addr_str[INET_ADDRSTRLEN];
@@ -176,7 +176,7 @@ bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
 		nexthop->mrib_metric_preference =
 			nexthop_tab[i].protocol_distance;
 		nexthop->mrib_route_metric = nexthop_tab[i].route_metric;
-		nexthop->last_lookup = addr;
+		nexthop->last_lookup.ipaddr_v4 = addr;
 		nexthop->last_lookup_time = pim_time_monotonic_usec();
 		nexthop->nbr = nbr;
 		return true;

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -402,7 +402,7 @@ static struct in_addr pim_rpf_find_rpf_addr(struct pim_upstream *up)
 		up->rpf.source_nexthop.interface,
 		up->rpf.source_nexthop.mrib_nexthop_addr.u.prefix4);
 	if (neigh)
-		rpf_addr = neigh->source_addr;
+		rpf_addr = neigh->source_addr.ipaddr_v4;
 	else
 		rpf_addr.s_addr = PIM_NET_INADDR_ANY;
 

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -259,9 +259,8 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 	grp.prefixlen = IPV4_MAX_BITLEN;
 	grp.u.prefix4 = up->sg.grp.ipaddr_v4;
 
-	if ((up->sg.src.ipaddr_v4.s_addr == INADDR_ANY
-	     && I_am_RP(pim, up->sg.grp.ipaddr_v4))
-	    || PIM_UPSTREAM_FLAG_TEST_FHR(up->flags))
+	if ((up->sg.src.ipaddr_v4.s_addr == INADDR_ANY && I_am_RP(pim, up->sg.grp.ipaddr_v4)) ||
+	    PIM_UPSTREAM_FLAG_TEST_FHR(up->flags))
 		neigh_needed = false;
 	pim_find_or_track_nexthop(pim, &nht_p, up, NULL, NULL);
 	if (!pim_ecmp_nexthop_lookup(pim, &rpf->source_nexthop, &src, &grp,

--- a/pimd/pim_rpf.h
+++ b/pimd/pim_rpf.h
@@ -35,7 +35,7 @@
     units applicable to the unicast routing protocol used.
 */
 struct pim_nexthop {
-	struct in_addr last_lookup;
+	struct ipaddr last_lookup;
 	long long last_lookup_time;
 	struct interface *interface;     /* RPF_interface(S) */
 	struct prefix mrib_nexthop_addr; /* MRIB.next_hop(S) */

--- a/pimd/pim_tlv.c
+++ b/pimd/pim_tlv.c
@@ -553,7 +553,8 @@ int pim_parse_addr_group(struct prefix_sg *sg, const uint8_t *buf, int buf_size)
 			return -3;
 		}
 
-		memcpy(&sg->grp.ipaddr_v4.s_addr, addr, sizeof(struct in_addr));
+		memcpy(&sg->grp.ipaddr_v4.s_addr, addr,
+		       sizeof(struct in_addr));
 
 		addr += sizeof(struct in_addr);
 

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -262,11 +262,11 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 	 * to INADDR_ANY. This is done in order to avoid de-registering for
 	 * 255.255.255.255 which is maintained for some reason..
 	 */
-	if (up->upstream_addr.s_addr != INADDR_ANY) {
+	if (up->upstream_addr.ipaddr_v4.s_addr != INADDR_ANY) {
 		/* Deregister addr with Zebra NHT */
 		nht_p.family = AF_INET;
 		nht_p.prefixlen = IPV4_MAX_BITLEN;
-		nht_p.u.prefix4 = up->upstream_addr;
+		nht_p.u.prefix4 = up->upstream_addr.ipaddr_v4;
 		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug(
 				"%s: Deregister upstream %s addr %pFX with Zebra NHT",
@@ -716,7 +716,7 @@ void pim_upstream_switch(struct pim_instance *pim, struct pim_upstream *up,
 {
 	enum pim_upstream_state old_state = up->join_state;
 
-	if (up->upstream_addr.s_addr == INADDR_ANY) {
+	if (up->upstream_addr.ipaddr_v4.s_addr == INADDR_ANY) {
 		if (PIM_DEBUG_PIM_EVENTS)
 			zlog_debug("%s: RPF not configured for %s", __func__,
 				   up->sg_str);
@@ -885,9 +885,9 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 	/* Set up->upstream_addr as INADDR_ANY, if RP is not
 	 * configured and retain the upstream data structure
 	 */
-	if (!pim_rp_set_upstream_addr(pim, &up->upstream_addr,
-				      sg->src.ipaddr_v4,
-				      sg->grp.ipaddr_v4)) {
+	if (!pim_rp_set_upstream_addr(pim, &up->upstream_addr.ipaddr_v4,
+				      sg->src.ipaddr_v4, 
+					  sg->grp.ipaddr_v4)) {
 		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: Received a (*,G) with no RP configured",
 				   __func__);
@@ -957,9 +957,8 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 		if (PIM_UPSTREAM_FLAG_TEST_SRC_NOCACHE(up->flags))
 			pim_upstream_keep_alive_timer_start(
 				up, pim->keep_alive_time);
-	} else if (up->upstream_addr.s_addr != INADDR_ANY) {
-		pim_upstream_update_use_rpt(up,
-				false /*update_mroute*/);
+	} else if (up->upstream_addr.ipaddr_v4.s_addr != INADDR_ANY) {
+		pim_upstream_update_use_rpt(up, false /*update_mroute*/);
 		rpf_result = pim_rpf_update(pim, up, NULL, __func__);
 		if (rpf_result == PIM_RPF_FAILURE) {
 			if (PIM_DEBUG_PIM_TRACE)
@@ -985,7 +984,7 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 	if (PIM_DEBUG_PIM_TRACE) {
 		zlog_debug(
 			"%s: Created Upstream %s upstream_addr %pI4 ref count %d increment",
-			__func__, up->sg_str, &up->upstream_addr,
+			__func__, up->sg_str, &up->upstream_addr.ipaddr_v4,
 			up->ref_count);
 	}
 
@@ -1936,7 +1935,7 @@ void pim_upstream_find_new_rpf(struct pim_instance *pim)
 	 * Scan all (S,G) upstreams searching for RPF'(S,G)=neigh_addr
 	 */
 	frr_each (rb_pim_upstream, &pim->upstream_head, up) {
-		if (up->upstream_addr.s_addr == INADDR_ANY) {
+		if (up->upstream_addr.ipaddr_v4.s_addr == INADDR_ANY) {
 			if (PIM_DEBUG_PIM_TRACE)
 				zlog_debug(
 					"%s: RP not configured for Upstream %s",

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -111,8 +111,7 @@ static void pim_upstream_find_new_children(struct pim_instance *pim,
 
 	frr_each (rb_pim_upstream, &pim->upstream_head, child) {
 		if ((up->sg.grp.ipaddr_v4.s_addr != INADDR_ANY)
-		    && (child->sg.grp.ipaddr_v4.s_addr
-			== up->sg.grp.ipaddr_v4.s_addr)
+		    && (child->sg.grp.ipaddr_v4.s_addr == up->sg.grp.ipaddr_v4.s_addr)
 		    && (child != up)) {
 			child->parent = up;
 			listnode_add_sort(up->sources, child);
@@ -670,15 +669,15 @@ void pim_upstream_update_use_rpt(struct pim_upstream *up,
 	 * In all other cases the source will stay along the RPT and
 	 * IIF=RPF_interface(RP).
 	 */
-	if (up->join_state == PIM_UPSTREAM_JOINED
-	    || PIM_UPSTREAM_FLAG_TEST_FHR(up->flags)
-	    || pim_if_connected_to_source(up->rpf.source_nexthop.interface,
-					  up->sg.src.ipaddr_v4)
-	    ||
-	    /* XXX - need to switch this to a more efficient
-	     * lookup API
-	     */
-	    I_am_RP(up->pim, up->sg.grp.ipaddr_v4))
+	if (up->join_state == PIM_UPSTREAM_JOINED ||
+			PIM_UPSTREAM_FLAG_TEST_FHR(up->flags) ||
+			pim_if_connected_to_source(
+				up->rpf.source_nexthop.interface,
+				up->sg.src.ipaddr_v4) ||
+			/* XXX - need to switch this to a more efficient
+			 * lookup API
+			 */
+			I_am_RP(up->pim, up->sg.grp.ipaddr_v4))
 		/* use SPT */
 		PIM_UPSTREAM_FLAG_UNSET_USE_RPT(up->flags);
 	else
@@ -801,8 +800,8 @@ void pim_upstream_switch(struct pim_instance *pim, struct pim_upstream *up,
 		/* IHR, Trigger SGRpt on *,G IIF to prune S,G from RPT towards
 		   RP.
 		   If I am RP for G then send S,G prune to its IIF. */
-		if (pim_upstream_is_sg_rpt(up) && up->parent
-		    && !I_am_RP(pim, up->sg.grp.ipaddr_v4))
+		if (pim_upstream_is_sg_rpt(up) && up->parent &&
+				!I_am_RP(pim, up->sg.grp.ipaddr_v4))
 			send_xg_jp = true;
 
 		pim_jp_agg_single_upstream_send(&up->rpf, up, 0 /* prune */);
@@ -887,7 +886,8 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 	 * configured and retain the upstream data structure
 	 */
 	if (!pim_rp_set_upstream_addr(pim, &up->upstream_addr,
-				      sg->src.ipaddr_v4, sg->grp.ipaddr_v4)) {
+				      sg->src.ipaddr_v4,
+				      sg->grp.ipaddr_v4)) {
 		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: Received a (*,G) with no RP configured",
 				   __func__);
@@ -1993,7 +1993,8 @@ bool pim_upstream_equal(const void *arg1, const void *arg2)
 	const struct pim_upstream *up2 = (const struct pim_upstream *)arg2;
 
 	if ((up1->sg.grp.ipaddr_v4.s_addr == up2->sg.grp.ipaddr_v4.s_addr)
-	    && (up1->sg.src.ipaddr_v4.s_addr == up2->sg.src.ipaddr_v4.s_addr))
+	    && (up1->sg.src.ipaddr_v4.s_addr
+		== up2->sg.src.ipaddr_v4.s_addr))
 		return true;
 
 	return false;

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -229,9 +229,9 @@ struct pim_upstream {
 	struct pim_instance *pim;
 	struct rb_pim_upstream_item upstream_rb;
 	struct pim_upstream *parent;
-	struct in_addr upstream_addr;     /* Who we are talking to */
-	struct in_addr upstream_register; /*Who we received a register from*/
-	struct prefix_sg sg;		  /* (S,G) group key */
+	struct ipaddr upstream_addr;     /* Who we are talking to */
+	struct ipaddr upstream_register; /*Who we received a register from*/
+	struct prefix_sg sg;		 /* (S,G) group key */
 	char sg_str[PIM_SG_LEN];
 	uint32_t flags;
 	struct channel_oil *channel_oil;

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -340,10 +340,11 @@ int pim_interface_config_write(struct vty *vty)
 
 				/* update source */
 				if (PIM_INADDR_ISNOT_ANY(
-					    pim_ifp->update_source)) {
+					    pim_ifp->update_source.ipaddr_v4)) {
 					char src_str[INET_ADDRSTRLEN];
 					pim_inet4_dump("<src?>",
-						       pim_ifp->update_source,
+						       pim_ifp->update_source
+							       .ipaddr_v4,
 						       src_str,
 						       sizeof(src_str));
 					vty_out(vty, " ip pim use-source %s\n",

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -356,7 +356,7 @@ static void pim_vxlan_orig_mr_up_add(struct pim_vxlan_sg *vxlan_sg)
 		if (!PIM_UPSTREAM_FLAG_TEST_STATIC_IIF(up->flags)) {
 			nht_p.family = AF_INET;
 			nht_p.prefixlen = IPV4_MAX_BITLEN;
-			nht_p.u.prefix4 = up->upstream_addr;
+			nht_p.u.prefix4 = up->upstream_addr.ipaddr_v4;
 			pim_delete_tracked_nexthop(vxlan_sg->pim, &nht_p, up,
 						   NULL);
 		}

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -721,7 +721,7 @@ static unsigned int pim_vxlan_sg_hash_key_make(const void *p)
 	const struct pim_vxlan_sg *vxlan_sg = p;
 
 	return (jhash_2words(vxlan_sg->sg.src.ipaddr_v4.s_addr,
-			     vxlan_sg->sg.grp.ipaddr_v4.s_addr, 0));
+				vxlan_sg->sg.grp.ipaddr_v4.s_addr, 0));
 }
 
 static bool pim_vxlan_sg_hash_eq(const void *p1, const void *p2)
@@ -730,8 +730,7 @@ static bool pim_vxlan_sg_hash_eq(const void *p1, const void *p2)
 	const struct pim_vxlan_sg *sg2 = p2;
 
 	return ((sg1->sg.src.ipaddr_v4.s_addr == sg2->sg.src.ipaddr_v4.s_addr)
-		&& (sg1->sg.grp.ipaddr_v4.s_addr
-		    == sg2->sg.grp.ipaddr_v4.s_addr));
+			&& (sg1->sg.grp.ipaddr_v4.s_addr == sg2->sg.grp.ipaddr_v4.s_addr));
 }
 
 static struct pim_vxlan_sg *pim_vxlan_sg_new(struct pim_instance *pim,

--- a/pimd/pim_vxlan.h
+++ b/pimd/pim_vxlan.h
@@ -114,9 +114,9 @@ static inline bool pim_vxlan_is_orig_mroute(struct pim_vxlan_sg *vxlan_sg)
 
 static inline bool pim_vxlan_is_local_sip(struct pim_upstream *up)
 {
-	return (up->sg.src.ipaddr_v4.s_addr != INADDR_ANY)
-	       && up->rpf.source_nexthop
-			  .interface && if_is_loopback(up->rpf.source_nexthop.interface);
+	return (up->sg.src.ipaddr_v4.s_addr != INADDR_ANY) &&
+		up->rpf.source_nexthop.interface &&
+		if_is_loopback(up->rpf.source_nexthop.interface);
 }
 
 static inline bool pim_vxlan_is_term_dev_cfg(struct pim_instance *pim,

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -829,11 +829,11 @@ void pim_forward_start(struct pim_ifchannel *ch)
 			       sizeof(source_str));
 		pim_inet4_dump("<group?>", ch->sg.grp.ipaddr_v4, group_str,
 			       sizeof(group_str));
-		pim_inet4_dump("<upstream?>", up->upstream_addr, upstream_str,
-			       sizeof(upstream_str));
+		pim_inet4_dump("<upstream?>", up->upstream_addr.ipaddr_v4,
+			       upstream_str, sizeof(upstream_str));
 		zlog_debug("%s: (S,G)=(%s,%s) oif=%s (%pI4)", __func__,
 			   source_str, group_str, ch->interface->name,
-			   &up->upstream_addr);
+			   &up->upstream_addr.ipaddr_v4);
 	}
 
 	if (PIM_IF_FLAG_TEST_PROTO_IGMP(ch->flags))

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -302,7 +302,7 @@ static int zclient_read_nexthop(struct pim_instance *pim,
 					AF_INET;
 				nexthop_tab[num_ifindex]
 					.nexthop_addr.u.prefix4 =
-					nbr->source_addr;
+					nbr->source_addr.ipaddr_v4;
 			}
 			++num_ifindex;
 			break;

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1083,8 +1083,8 @@ static int netlink_route_change_read_multicast(struct nlmsghdr *h,
 		zlog_debug(
 			"MCAST VRF: %s(%d) %s (%pI4,%pI4) IIF: %s(%d) OIF: %s jiffies: %lld",
 			zvrf_name(zvrf), vrf, nl_msg_type_to_str(h->nlmsg_type),
-			&m->sg.src.ipaddr_v4, &m->sg.grp.ipaddr_v4,
-			ifp ? ifp->name : "Unknown", iif, oif_list,
+			&m->sg.src.ipaddr_v4, &m->sg.grp.ipaddr_v4, ifp ? ifp->name : "Unknown",
+			iif, oif_list,
 			m->lastused);
 	}
 	return 0;
@@ -2247,10 +2247,8 @@ int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *in)
 
 	nl_attr_put32(&req.n, sizeof(req), RTA_IIF, mroute->ifindex);
 	nl_attr_put32(&req.n, sizeof(req), RTA_OIF, mroute->ifindex);
-	nl_attr_put32(&req.n, sizeof(req), RTA_SRC,
-		      mroute->sg.src.ipaddr_v4.s_addr);
-	nl_attr_put32(&req.n, sizeof(req), RTA_DST,
-		      mroute->sg.grp.ipaddr_v4.s_addr);
+	nl_attr_put32(&req.n, sizeof(req), RTA_SRC, mroute->sg.src.ipaddr_v4.s_addr);
+	nl_attr_put32(&req.n, sizeof(req), RTA_DST, mroute->sg.grp.ipaddr_v4.s_addr);
 	/*
 	 * What?
 	 *

--- a/zebra/zebra_mroute.c
+++ b/zebra/zebra_mroute.c
@@ -47,10 +47,8 @@ void zebra_ipmr_route_stats(ZAPI_HANDLER_ARGS)
 		char sbuf[40];
 		char gbuf[40];
 
-		inet_ntop(AF_INET, &mroute.sg.src.ipaddr_v4, sbuf,
-			  sizeof(sbuf));
-		inet_ntop(AF_INET, &mroute.sg.grp.ipaddr_v4, gbuf,
-			  sizeof(gbuf));
+		inet_ntop(AF_INET, &mroute.sg.src.ipaddr_v4, sbuf, sizeof(sbuf));
+		inet_ntop(AF_INET, &mroute.sg.grp.ipaddr_v4, gbuf, sizeof(gbuf));
 
 		zlog_debug("Asking for (%s,%s)[%s(%u)] mroute information",
 			   sbuf, gbuf, zvrf->vrf->name, zvrf->vrf->vrf_id);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5930,7 +5930,7 @@ static unsigned int zebra_vxlan_sg_hash_key_make(const void *p)
 	const struct zebra_vxlan_sg *vxlan_sg = p;
 
 	return (jhash_2words(vxlan_sg->sg.src.ipaddr_v4.s_addr,
-			     vxlan_sg->sg.grp.ipaddr_v4.s_addr, 0));
+				vxlan_sg->sg.grp.ipaddr_v4.s_addr, 0));
 }
 
 static bool zebra_vxlan_sg_hash_eq(const void *p1, const void *p2)
@@ -5939,8 +5939,7 @@ static bool zebra_vxlan_sg_hash_eq(const void *p1, const void *p2)
 	const struct zebra_vxlan_sg *sg2 = p2;
 
 	return ((sg1->sg.src.ipaddr_v4.s_addr == sg2->sg.src.ipaddr_v4.s_addr)
-		&& (sg1->sg.grp.ipaddr_v4.s_addr
-		    == sg2->sg.grp.ipaddr_v4.s_addr));
+		&& (sg1->sg.grp.ipaddr_v4.s_addr == sg2->sg.grp.ipaddr_v4.s_addr));
 }
 
 static struct zebra_vxlan_sg *zebra_vxlan_sg_new(struct zebra_vrf *zvrf,


### PR DESCRIPTION
Changed struct in_addr to struct ipaddr at required places
which are to be used in both IPv4 and IPv6(Both MLD and IGMP).

Co-authored-by: Mobashshera Rasool <mrasool@vmware.com>
Co-authored-by: Sarita Patra <saritap@vmware.com>
Co-authored-by: Sai Gomathi <nsaigomathi@vmware.com>
Signed-off-by: Abhishek N R <abnr@vmware.com>